### PR TITLE
add doclets.io config (jsdoc pages)

### DIFF
--- a/.doclets.yml
+++ b/.doclets.yml
@@ -1,0 +1,3 @@
+dir: src
+articles:
+  - Readme: README.md


### PR DESCRIPTION
Adds hosted JSDoc API documentation hosted on [doclets.io](https://doclets.io) service. Future tags and master branch will be published automatically.

[Preview generated with my account](https://doclets.io/lipp/postgraphql/add-to-doclets)

@calebmer    If you like this, you are very welcomed to login to https://doclets.io with GitHub OAuth. If you don't like it, I'd be happy to hear what you don't like about it :)

Steps required (3min):
1) @calebmer     logs in to doclets.io
2) @calebmer    adds async
3) someone merges this PR