### PR TITLE
fix(graphql): enum types get cached (#35)

### DIFF
--- a/examples/forum/schema.sql
+++ b/examples/forum/schema.sql
@@ -19,13 +19,16 @@ set search_path = forum_example, forum_example_utils;
 -------------------------------------------------------------------------------
 -- Basic Tables
 
+create type entity_status as enum('new','updated','deleted');
+
 create table person (
   id               serial not null primary key,
   given_name       varchar(64) not null,
   family_name      varchar(64),
   about            text,
   created_at       timestamp,
-  updated_at       timestamp
+  updated_at       timestamp,
+  status           entity_status
 );
 
 comment on table person is 'A user of the forum.';
@@ -45,7 +48,8 @@ create table post (
   topic            post_topic,
   body             text,
   created_at       timestamp,
-  updated_at       timestamp
+  updated_at       timestamp,
+  status           entity_status
 );
 
 comment on table post is 'A forum post written by a user.';

--- a/src/graphql/getColumnType.js
+++ b/src/graphql/getColumnType.js
@@ -108,7 +108,9 @@ const getColumnEnumType = memoize(enum_ => {
       .map(variant => [toUpper(snakeCase(variant)), { value: variant }])
     ),
   })
-}, enum_ => { return enum_.name })
+}, enum_ => {
+  return enum_.name
+})
 
 const getColumnGraphqlType = memoize(column => {
   const wrapType = type => (column.isNullable ? type : new GraphQLNonNull(type))
@@ -119,10 +121,9 @@ const getColumnGraphqlType = memoize(column => {
     return wrapType(internalType)
 
   // If the column has an enum type, we need to create a `GraphQLEnumType`.
-  const enum_ = column.getEnum();
-  if (enum_) {
-    return wrapType(getColumnEnumType(enum_));
-  }
+  const enum_ = column.getEnum()
+  if (enum_)
+    return wrapType(getColumnEnumType(enum_))
 
   // Otherwise, just return `GraphQLString`.
   return wrapType(GraphQLString)

--- a/src/graphql/getColumnType.js
+++ b/src/graphql/getColumnType.js
@@ -94,11 +94,22 @@ const postgresToGraphQLTypes = new Map([
 ])
 
 /**
- * Gets a GraphQL type for a PostgreSQL type.
- *
- * @param {Column} column
- * @returns {GraphQLType}
- */
+* Gets a GraphQL type for a PostgreSQL type.
+*
+* @param {Column} column
+* @returns {GraphQLType}
+*/
+const getColumnEnumType = memoize(enum_ => {
+  return new GraphQLEnumType({
+    name: upperFirst(camelCase(enum_.name)),
+    description: enum_.description,
+    values: fromPairs(
+      enum_.variants
+      .map(variant => [toUpper(snakeCase(variant)), { value: variant }])
+    ),
+  })
+}, enum_ => { return enum_.name })
+
 const getColumnGraphqlType = memoize(column => {
   const wrapType = type => (column.isNullable ? type : new GraphQLNonNull(type))
   const internalType = postgresToGraphQLTypes.get(column.type)
@@ -107,18 +118,10 @@ const getColumnGraphqlType = memoize(column => {
   if (internalType)
     return wrapType(internalType)
 
-  const enum_ = column.getEnum()
-
   // If the column has an enum type, we need to create a `GraphQLEnumType`.
+  const enum_ = column.getEnum();
   if (enum_) {
-    return wrapType(new GraphQLEnumType({
-      name: upperFirst(camelCase(enum_.name)),
-      description: enum_.description,
-      values: fromPairs(
-        enum_.variants
-        .map(variant => [toUpper(snakeCase(variant)), { value: variant }])
-      ),
-    }))
+    return wrapType(getColumnEnumType(enum_));
   }
 
   // Otherwise, just return `GraphQLString`.

--- a/tests/graphql/getColumnType.test.js
+++ b/tests/graphql/getColumnType.test.js
@@ -84,6 +84,12 @@ describe('getColumnType', () => {
       expect(enumType.name).toEqual('TestEnum')
     })
 
+    it('will return same reference for enum with same name', () => {
+      const enumFirst = getEnum()
+      const enumSecond = getEnum()
+      expect(enumFirst).toBe(enumSecond)
+    })
+
     it('will correctly format variants', () => {
       const enumType = getEnum()
       expect(enumType.getValues()).toEqual([


### PR DESCRIPTION
Fix for https://github.com/calebmer/postgraphql/issues/35

Enum types get cashed using default memoize resolver. Removed schema validation error