### PR TITLE
Deprecate nodes filter

### DIFF
--- a/src/graphql/createConnectionArgs.js
+++ b/src/graphql/createConnectionArgs.js
@@ -50,6 +50,7 @@ const createConnectionArgs = (table, ignoreColumnConditions = []) => ({
       'items will be in ascending order. `false` by default.',
     defaultValue: false,
   },
+  // DEPRECATED: Remove this entirely
   ...fromPairs(
     table
     .getColumns()
@@ -62,10 +63,6 @@ const createConnectionArgs = (table, ignoreColumnConditions = []) => ({
       description:
         'Filters the resulting set with an equality test on the ' +
         `${column.getMarkdownFieldName()} field.`,
-      // TODO: Deprecate this…
-      // deprecationReason:
-      //   'Simple equality testing is insufficient for the nodes field and just ' +
-      //   'adds noise. Instead use procedures for custom set filtering.',
     }])
   ),
 })


### PR DESCRIPTION
I want to deprecate being able to do queries like `postNodes(help: TOPIC)` which uses an equality test to filter the nodes. I feel like it adds too much noise to the query arguments list for very little gain, it especially gets weird when you want to start matching `body` or long form text fields. Procedures also are a better more flexible way to implement this feature on a case by case basis.

I feel like we should reconsider this feature and try to find a solution that works better with the GraphQL type system and allows us to use many different operators outside of just `=`.