### PR TITLE
Add Relay viewer field

### DIFF
--- a/src/graphql/createViewerField.js
+++ b/src/graphql/createViewerField.js
@@ -1,6 +1,6 @@
 import { memoize } from 'lodash'
 import { GraphQLObjectType, GraphQLNonNull } from 'graphql'
-import createQueryFields from './createQueryFields.js'
+import createQueryFields from './query/createQueryFields.js'
 
 const createViewerField = memoize(schema => ({
   type: new GraphQLNonNull(new GraphQLObjectType({

--- a/src/graphql/createViewerField.js
+++ b/src/graphql/createViewerField.js
@@ -1,20 +1,35 @@
 import { memoize } from 'lodash'
-import { GraphQLObjectType, GraphQLNonNull } from 'graphql'
+import { GraphQLObjectType, GraphQLNonNull, GraphQLID } from 'graphql'
+import { $$isViewer } from '../symbols.js'
+import { NodeType } from './types'
 import createQueryFields from './query/createQueryFields.js'
 
 const createViewerField = memoize(schema => ({
   type: new GraphQLNonNull(new GraphQLObjectType({
     name: 'Viewer',
-    description: '',
-    fields: createQueryFields(schema),
+    description: 'The viewer type, provides a “view” into your data. To be used with Relay.',
+    interfaces: [NodeType],
+    isTypeOf: value => value[$$isViewer],
+    fields: {
+      ...createQueryFields(schema),
+      id: {
+        type: GraphQLID,
+        description:
+          'An identifier for the viewer node. Just the plain string “viewer.” ' +
+          'Can be used to refetch the viewer object in the `node` field. This ' +
+          'is required for Relay.',
+
+        resolve: () => 'viewer',
+      },
+    },
   })),
 
   description:
-    'A single entry query for advanced data clients like Relay. Nothing ' +
+    'A single entry query for the advanced data client Relay. Nothing ' +
     'special at all, if you don’t know what this field is for, you probably ' +
     'don’t need it.',
 
-  resolve: source => source || {},
+  resolve: () => ({ [$$isViewer]: true }),
 }))
 
 export default createViewerField

--- a/src/graphql/mutation/createDeleteMutationField.js
+++ b/src/graphql/mutation/createDeleteMutationField.js
@@ -3,7 +3,9 @@ import { $$rowTable } from '../../symbols.js'
 import SQLBuilder from '../../SQLBuilder.js'
 import getType from '../getType.js'
 import createTableType from '../createTableType.js'
-import { inputClientMutationId, payloadClientMutationId } from './clientMutationId.js'
+import getPayloadInterface from './getPayloadInterface.js'
+import getPayloadFields from './getPayloadFields.js'
+import { inputClientMutationId } from './clientMutationId.js'
 
 import {
   GraphQLNonNull,
@@ -53,13 +55,14 @@ const createPayloadType = table =>
   new GraphQLObjectType({
     name: `Delete${table.getTypeName()}Payload`,
     description: `Contains the ${table.getMarkdownTypeName()} node deleted by the mutation.`,
+    interfaces: [getPayloadInterface(table.schema)],
     fields: {
       [table.getFieldName()]: {
         type: createTableType(table),
         description: `The deleted ${table.getMarkdownTypeName()}.`,
         resolve: source => source.output,
       },
-      clientMutationId: payloadClientMutationId,
+      ...getPayloadFields(table.schema),
     },
   })
 

--- a/src/graphql/mutation/createInsertMutationField.js
+++ b/src/graphql/mutation/createInsertMutationField.js
@@ -3,7 +3,9 @@ import { $$rowTable } from '../../symbols.js'
 import SQLBuilder from '../../SQLBuilder.js'
 import getColumnType from '../getColumnType.js'
 import createTableType from '../createTableType.js'
-import { inputClientMutationId, payloadClientMutationId } from './clientMutationId.js'
+import getPayloadInterface from './getPayloadInterface.js'
+import getPayloadFields from './getPayloadFields.js'
+import { inputClientMutationId } from './clientMutationId.js'
 
 import {
   getNullableType,
@@ -52,6 +54,7 @@ const createPayloadType = table =>
   new GraphQLObjectType({
     name: `Insert${table.getTypeName()}Payload`,
     description: `Contains the ${table.getMarkdownTypeName()} node inserted by the mutation.`,
+    interfaces: [getPayloadInterface(table.schema)],
 
     fields: {
       [table.getFieldName()]: {
@@ -59,7 +62,7 @@ const createPayloadType = table =>
         description: `The inserted ${table.getMarkdownTypeName()}.`,
         resolve: source => source.output,
       },
-      clientMutationId: payloadClientMutationId,
+      ...getPayloadFields(table.schema),
     },
   })
 

--- a/src/graphql/mutation/createProcedureMutationField.js
+++ b/src/graphql/mutation/createProcedureMutationField.js
@@ -3,7 +3,9 @@ import { GraphQLObjectType, GraphQLNonNull, GraphQLInputObjectType } from 'graph
 import createProcedureReturnType from '../createProcedureReturnType.js'
 import createProcedureArgs from '../createProcedureArgs.js'
 import resolveProcedure from '../resolveProcedure.js'
-import { inputClientMutationId, payloadClientMutationId } from './clientMutationId.js'
+import getPayloadInterface from './getPayloadInterface.js'
+import getPayloadFields from './getPayloadFields.js'
+import { inputClientMutationId } from './clientMutationId.js'
 
 const createProcedureMutationField = procedure => ({
   type: createPayloadType(procedure),
@@ -42,6 +44,7 @@ const createPayloadType = procedure =>
   new GraphQLObjectType({
     name: `${upperFirst(camelCase(procedure.name))}Payload`,
     description: `The payload returned by the ${procedure.getMarkdownFieldName()}`,
+    interfaces: [getPayloadInterface(procedure.schema)],
 
     // Our payload has two fields, one is the return type. The name of which is
     // the type name, so a `Circle` would have a field name of `circle` and a
@@ -56,7 +59,7 @@ const createPayloadType = procedure =>
         description: `The actual value returned by ${procedure.getMarkdownFieldName()}`,
         resolve: ({ output }) => output,
       },
-      clientMutationId: payloadClientMutationId,
+      ...getPayloadFields(procedure.schema),
     },
   })
 

--- a/src/graphql/mutation/createUpdateMutationField.js
+++ b/src/graphql/mutation/createUpdateMutationField.js
@@ -3,7 +3,9 @@ import { $$rowTable } from '../../symbols.js'
 import SQLBuilder from '../../SQLBuilder.js'
 import getType from '../getType.js'
 import createTableType from '../createTableType.js'
-import { inputClientMutationId, payloadClientMutationId } from './clientMutationId.js'
+import getPayloadInterface from './getPayloadInterface.js'
+import getPayloadFields from './getPayloadFields.js'
+import { inputClientMutationId } from './clientMutationId.js'
 
 import {
   GraphQLNonNull,
@@ -63,13 +65,14 @@ const createPayloadType = table =>
   new GraphQLObjectType({
     name: `Update${table.getTypeName()}Payload`,
     description: `Contains the ${table.getMarkdownTypeName()} node updated by the mutation.`,
+    interfaces: [getPayloadInterface(table.schema)],
     fields: {
       [table.getFieldName()]: {
         type: createTableType(table),
         description: `The updated ${table.getMarkdownTypeName()}.`,
         resolve: source => source.output,
       },
-      clientMutationId: payloadClientMutationId,
+      ...getPayloadFields(table.schema),
     },
   })
 

--- a/src/graphql/mutation/getPayloadFields.js
+++ b/src/graphql/mutation/getPayloadFields.js
@@ -1,0 +1,10 @@
+import { memoize } from 'lodash'
+import createViewerField from '../createViewerField.js'
+import { payloadClientMutationId } from './clientMutationId.js'
+
+const getPayloadFields = memoize(schema => ({
+  clientMutationId: payloadClientMutationId,
+  viewer: createViewerField(schema),
+}))
+
+export default getPayloadFields

--- a/src/graphql/mutation/getPayloadInterface.js
+++ b/src/graphql/mutation/getPayloadInterface.js
@@ -1,0 +1,21 @@
+import { memoize } from 'lodash'
+import { GraphQLInterfaceType } from 'graphql'
+import { payloadClientMutationId } from './clientMutationId.js'
+import createViewerField from '../createViewerField.js'
+
+const getPayloadInterface = memoize(schema =>
+  new GraphQLInterfaceType({
+    name: 'Payload',
+    description: 'The payload of any mutation which contains a few important fields.',
+
+    // We really don’t care about resolving a payload’s type, so just return null.
+    resolveType: () => null,
+
+    fields: {
+      clientMutationId: payloadClientMutationId,
+      viewer: createViewerField(schema),
+    },
+  })
+)
+
+export default getPayloadInterface

--- a/src/graphql/query/createNodeQueryField.js
+++ b/src/graphql/query/createNodeQueryField.js
@@ -1,5 +1,6 @@
 import { memoize } from 'lodash'
 import { GraphQLNonNull, GraphQLID } from 'graphql'
+import { $$isViewer } from '../../symbols.js'
 import { NodeType, fromID } from '../types.js'
 import resolveTableSingle from '../resolveTableSingle.js'
 
@@ -18,6 +19,11 @@ const createNodeQueryField = schema => {
 
     resolve: (source, args, context) => {
       const { id } = args
+
+      // If the id is just `viewer`, we are trying to refetch the viewer node.
+      if (id === 'viewer')
+        return { [$$isViewer]: true }
+
       const { tableName, values } = fromID(id)
       const table = getTable(tableName)
 

--- a/src/graphql/query/createQueryFields.js
+++ b/src/graphql/query/createQueryFields.js
@@ -1,0 +1,26 @@
+import { memoize, fromPairs, ary, assign } from 'lodash'
+import createNodeQueryField from './createNodeQueryField.js'
+import createTableQueryFields from './createTableQueryFields.js'
+import createProcedureQueryField from './createProcedureQueryField.js'
+
+const createQueryFields = memoize(schema => ({
+  // Add the node query field.
+  node: createNodeQueryField(schema),
+  // Add fields for procedures.
+  ...fromPairs(
+    schema
+    .getProcedures()
+    .filter(({ isMutation }) => !isMutation)
+    .filter(procedure => !procedure.hasTableArg())
+    .map(procedure => [procedure.getFieldName(), createProcedureQueryField(procedure)])
+  ),
+  // Add the table query fields.
+  ...(
+    schema
+    .getTables()
+    .map(table => createTableQueryFields(table))
+    .reduce(ary(assign, 2), {})
+  ),
+}))
+
+export default createQueryFields

--- a/src/graphql/query/createQueryType.js
+++ b/src/graphql/query/createQueryType.js
@@ -1,8 +1,6 @@
-import { fromPairs, ary, assign } from 'lodash'
 import { GraphQLObjectType } from 'graphql'
-import createNodeQueryField from './createNodeQueryField.js'
-import createTableQueryFields from './createTableQueryFields.js'
-import createProcedureQueryField from './createProcedureQueryField.js'
+import createQueryFields from './createQueryFields.js'
+import createViewerField from './createViewerField.js'
 
 /**
  * Creates the Query type for the entire schema. To see the fields created for
@@ -16,23 +14,8 @@ const createQueryType = schema =>
     name: 'Query',
     description: schema.description || 'The entry type for GraphQL queries.',
     fields: {
-      // Add the node query field.
-      node: createNodeQueryField(schema),
-      // Add fields for procedures.
-      ...fromPairs(
-        schema
-        .getProcedures()
-        .filter(({ isMutation }) => !isMutation)
-        .filter(procedure => !procedure.hasTableArg())
-        .map(procedure => [procedure.getFieldName(), createProcedureQueryField(procedure)])
-      ),
-      // Add the table query fields.
-      ...(
-        schema
-        .getTables()
-        .map(table => createTableQueryFields(table))
-        .reduce(ary(assign, 2), {})
-      ),
+      ...createQueryFields(schema),
+      viewer: createViewerField(schema),
     },
   })
 

--- a/src/graphql/query/createQueryType.js
+++ b/src/graphql/query/createQueryType.js
@@ -1,6 +1,6 @@
 import { GraphQLObjectType } from 'graphql'
+import createViewerField from '../createViewerField.js'
 import createQueryFields from './createQueryFields.js'
-import createViewerField from './createViewerField.js'
 
 /**
  * Creates the Query type for the entire schema. To see the fields created for

--- a/src/graphql/query/createViewerField.js
+++ b/src/graphql/query/createViewerField.js
@@ -1,0 +1,20 @@
+import { memoize } from 'lodash'
+import { GraphQLObjectType, GraphQLNonNull } from 'graphql'
+import createQueryFields from './createQueryFields.js'
+
+const createViewerField = memoize(schema => ({
+  type: new GraphQLNonNull(new GraphQLObjectType({
+    name: 'Viewer',
+    description: '',
+    fields: createQueryFields(schema),
+  })),
+
+  description:
+    'A single entry query for advanced data clients like Relay. Nothing ' +
+    'special at all, if you don’t know what this field is for, you probably ' +
+    'don’t need it.',
+
+  resolve: source => source || {},
+}))
+
+export default createViewerField

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -1,1 +1,2 @@
 export const $$rowTable = Symbol('postgraphql/rowTable')
+export const $$isViewer = Symbol('postgraphql/isViewer')

--- a/tests/integration/fixtures/viewer-mutation.graphql
+++ b/tests/integration/fixtures/viewer-mutation.graphql
@@ -1,0 +1,16 @@
+mutation Viewer {
+  insertRelatedNodes(input: { noteA: "a", noteB: "b" }) { ...payload }
+  insertThing(input: { note: "a" }) { ...payload }
+  updateThing(input: { rowId: 1, newNote: "b" }) { ...payload }
+  deleteThing(input: { rowId: 1 }) { ...payload }
+}
+
+fragment payload on Payload {
+  viewer {
+    thing(id: "dGhpbmc6NQ==") {
+      id
+      rowId
+      note
+    }
+  }
+}

--- a/tests/integration/fixtures/viewer-mutation.json
+++ b/tests/integration/fixtures/viewer-mutation.json
@@ -1,0 +1,40 @@
+{
+  "data": {
+    "insertRelatedNodes": {
+      "viewer": {
+        "thing": {
+          "id": "dGhpbmc6NQ==",
+          "rowId": 5,
+          "note": "baz"
+        }
+      }
+    },
+    "insertThing": {
+      "viewer": {
+        "thing": {
+          "id": "dGhpbmc6NQ==",
+          "rowId": 5,
+          "note": "baz"
+        }
+      }
+    },
+    "updateThing": {
+      "viewer": {
+        "thing": {
+          "id": "dGhpbmc6NQ==",
+          "rowId": 5,
+          "note": "baz"
+        }
+      }
+    },
+    "deleteThing": {
+      "viewer": {
+        "thing": {
+          "id": "dGhpbmc6NQ==",
+          "rowId": 5,
+          "note": "baz"
+        }
+      }
+    }
+  }
+}

--- a/tests/integration/fixtures/viewer-query.graphql
+++ b/tests/integration/fixtures/viewer-query.graphql
@@ -1,0 +1,12 @@
+query Viewer {
+  thing(id: "dGhpbmc6NQ==") { ...thing }
+  viewer {
+    thing(id: "dGhpbmc6NQ==") { ...thing }
+  }
+}
+
+fragment thing on Thing {
+  id
+  rowId
+  note
+}

--- a/tests/integration/fixtures/viewer-query.graphql
+++ b/tests/integration/fixtures/viewer-query.graphql
@@ -1,7 +1,14 @@
 query Viewer {
   thing(id: "dGhpbmc6NQ==") { ...thing }
   viewer {
+    id
     thing(id: "dGhpbmc6NQ==") { ...thing }
+  }
+  node(id: "viewer") {
+    id
+    ... on Viewer {
+      thing(id: "dGhpbmc6NQ==") { ...thing }
+    }
   }
 }
 

--- a/tests/integration/fixtures/viewer-query.json
+++ b/tests/integration/fixtures/viewer-query.json
@@ -6,6 +6,15 @@
       "note": "baz"
     },
     "viewer": {
+      "id": "viewer",
+      "thing": {
+        "id": "dGhpbmc6NQ==",
+        "rowId": 5,
+        "note": "baz"
+      }
+    },
+    "node": {
+      "id": "viewer",
       "thing": {
         "id": "dGhpbmc6NQ==",
         "rowId": 5,

--- a/tests/integration/fixtures/viewer-query.json
+++ b/tests/integration/fixtures/viewer-query.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "thing": {
+      "id": "dGhpbmc6NQ==",
+      "rowId": 5,
+      "note": "baz"
+    },
+    "viewer": {
+      "thing": {
+        "id": "dGhpbmc6NQ==",
+        "rowId": 5,
+        "note": "baz"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a Relay viewer field to the root query type and to all of the mutation payloads. @hardchor, @msimulcik is this what you’re looking for?

Closes #38 and maybe #43.