### PR TITLE
feat(postgres): add custom types to table filter.

### DIFF
--- a/src/graphql/mutation/createMutationType.js
+++ b/src/graphql/mutation/createMutationType.js
@@ -22,6 +22,7 @@ const createMutationType = schema =>
       ...(
         schema
         .getTables()
+        .filter(table => table.kind === 'r')
         .map(table => createMutationFields(table))
         .reduce(ary(assign, 2), {})
       ),

--- a/src/graphql/mutation/createMutationType.js
+++ b/src/graphql/mutation/createMutationType.js
@@ -15,7 +15,6 @@ const createMutationType = schema =>
         schema
         .getProcedures()
         .filter(({ isMutation }) => isMutation)
-        .filter(procedure => !procedure.hasTableArg())
         .map(procedure => [procedure.getFieldName(), createProcedureMutationField(procedure)])
       ),
       // Add standard fields for tables.

--- a/src/postgres/catalog.js
+++ b/src/postgres/catalog.js
@@ -120,10 +120,11 @@ export class Schema {
  * @member {ForeignKey[]} reverseForeignKeys
  */
 export class Table {
-  constructor ({ schema, name, description }) {
+  constructor ({ schema, name, description, kind }) {
     this.schema = schema
     this.name = name
     this.description = description
+    this.kind = kind
   }
 
   getColumns = once(() => {

--- a/src/postgres/getCatalog.js
+++ b/src/postgres/getCatalog.js
@@ -72,14 +72,15 @@ const addTables = (client, catalog) =>
     select
       n.nspname as "schemaName",
       c.relname as "name",
-      d.description as "description"
+      d.description as "description",
+      c.relkind as "kind"
     from
       pg_catalog.pg_class as c
       left join pg_catalog.pg_namespace as n on n.oid = c.relnamespace
       left join pg_catalog.pg_description as d on d.objoid = c.oid and d.objsubid = 0
     where
       n.nspname not in ('pg_catalog', 'information_schema') and
-      c.relkind in ('r', 'v', 'm', 'f');
+      c.relkind in ('r', 'v', 'm', 'f', 'c');
   `)
   .then(({ rows }) => rows)
   .map(row => new Table({
@@ -111,7 +112,7 @@ const addColumns = (client, catalog) =>
         cp.conkey::int[] @> array[a.attnum::int]
     where
       n.nspname not in ('pg_catalog', 'information_schema') and
-      c.relkind in ('r', 'v', 'm', 'f') and
+      c.relkind in ('r', 'v', 'm', 'f', 'c') and
       a.attnum > 0 and
       not a.attisdropped
     order by
@@ -165,7 +166,7 @@ const addTableTypes = (client, catalog) =>
       left join pg_catalog.pg_namespace as n on n.oid = c.relnamespace
     where
       n.nspname not in ('pg_catalog', 'information_schema') and
-      c.relkind in ('r', 'v', 'm', 'f');
+      c.relkind in ('r', 'v', 'm', 'f', 'c');
   `)
   .then(({ rows }) => rows)
   .map(row => new TableType({

--- a/tests/graphql/mutation/createMutationType.test.js
+++ b/tests/graphql/mutation/createMutationType.test.js
@@ -1,5 +1,5 @@
 import expect from 'expect'
-import { TestSchema, TestTable } from '../../helpers.js'
+import { TestSchema, TestTable, TestProcedure, TestType } from '../../helpers.js'
 import createMutationType from '#/graphql/mutation/createMutationType.js'
 
 describe('createMutationType', () => {
@@ -11,5 +11,42 @@ describe('createMutationType', () => {
     expect(mutationType._typeConfig.fields.insertTest).toExist()
     expect(mutationType._typeConfig.fields.insertMyCustomType).toNotExist()
     expect(mutationType._typeConfig.fields.insertMyView).toNotExist()
+  })
+
+  it('includes volatile procedures that have a table type as their first argument as a mutation', () => {
+    const schema = new TestSchema()
+
+    schema.catalog.addProcedure(new TestProcedure({
+      name: 'volatile_table_type_proc',
+      isMutation: true,
+      schema,
+      args: new Map([
+        ['a', new TestType(123, new TestTable())],
+      ]),
+    }))
+
+    schema.catalog.addProcedure(new TestProcedure({
+      name: 'volatile_scalar_type_proc',
+      isMutation: true,
+      schema,
+      args: new Map([
+        ['a', new TestType()],
+      ]),
+    }))
+
+    schema.catalog.addProcedure(new TestProcedure({
+      name: 'strict_table_type_proc',
+      isMutation: false,
+      isStrict: true,
+      schema,
+      args: new Map([
+        ['a', new TestType(123, new TestTable())],
+      ]),
+    }))
+
+    const mutationType = createMutationType(schema)
+    expect(mutationType._typeConfig.fields.volatileTableTypeProc).toExist()
+    expect(mutationType._typeConfig.fields.volatileScalarTypeProc).toExist()
+    expect(mutationType._typeConfig.fields.strictTableTypeProc).toNotExist()
   })
 })

--- a/tests/graphql/mutation/createMutationType.test.js
+++ b/tests/graphql/mutation/createMutationType.test.js
@@ -1,0 +1,15 @@
+import expect from 'expect'
+import { TestSchema, TestTable } from '../../helpers.js'
+import createMutationType from '#/graphql/mutation/createMutationType.js'
+
+describe('createMutationType', () => {
+  it('generates mutations for ordinary tables only', () => {
+    const schema = new TestSchema()
+    schema.catalog.addTable(new TestTable({ name: 'my_custom_type', kind: 'c', schema }))
+    schema.catalog.addTable(new TestTable({ name: 'my_view', kind: 'v', schema }))
+    const mutationType = createMutationType(schema)
+    expect(mutationType._typeConfig.fields.insertTest).toExist()
+    expect(mutationType._typeConfig.fields.insertMyCustomType).toNotExist()
+    expect(mutationType._typeConfig.fields.insertMyView).toNotExist()
+  })
+})

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -19,8 +19,8 @@ export class TestSchema extends c.Schema {
 }
 
 export class TestTable extends c.Table {
-  constructor ({ name = 'test', schema = new TestSchema(), ...config } = {}) {
-    super({ name, schema, ...config })
+  constructor ({ name = 'test', schema = new TestSchema(), kind = 'r', ...config } = {}) {
+    super({ name, schema, kind, ...config })
     this.schema.catalog.addTable(this)
     this.schema.catalog.addColumn(new TestColumn({ table: this, isPrimaryKey: true }))
   }


### PR DESCRIPTION
This request expands the table definition to include custom types. I would like to use custom types in functions to represent data I want to return but that I do not want to persistently store, so it would be good for graphql to represent these types in its type system.

Currently if I add a custom type as a function return, graphql represents it as a String.

Not sure if you are happy to have as part of "tables" as I have done here, but let me know if this is alright or if you want to have a discreet type for it and have it inherit from the `Type` class as per enums, I was just following the KISS principle 😄 .