### PR TITLE
fix(graphql): explicitly check input values for undefined

### DIFF
--- a/src/graphql/mutation/createUpdateMutationField.js
+++ b/src/graphql/mutation/createUpdateMutationField.js
@@ -90,7 +90,7 @@ const resolveUpdate = table => {
 
     for (const column of columns) {
       const value = input[`new${upperFirst(column.getFieldName())}`]
-      if (!value) continue
+      if (typeof value === 'undefined') continue
       setClauses.push(`"${column.name}" = $`)
       setValues.push(value)
     }


### PR DESCRIPTION
Otherwise boolean and null values get coerced which will render
undesired result.