### PR TITLE
Add support for user defined domains

### DIFF
--- a/src/graphql/getType.js
+++ b/src/graphql/getType.js
@@ -98,6 +98,10 @@ const getType = memoize(type => {
     })
   }
 
+  // If the type is a domain, return the underlying type
+  if (type.isDomain)
+    return getType(type.baseType)
+
   // If this type is a table type, use the PostGraphQL table type.
   if (type.isTableType)
     return createTableType(type.table)

--- a/src/postgres/catalog.js
+++ b/src/postgres/catalog.js
@@ -251,6 +251,24 @@ export class Enum extends Type {
 }
 
 /**
+ * Represents a user defined domain PostgreSQL column.
+ *
+ * @member {Schema} schema
+ * @member {string} name
+ * @member {Type} baseType
+ */
+export class Domain extends Type {
+  isDomain = true
+
+  constructor ({ id, schema, name, baseType }) {
+    super(id)
+    this.schema = schema
+    this.name = name
+    this.baseType = baseType
+  }
+}
+
+/**
  * Represents a composite PostgreSQL table type.
  *
  * @member {Table} table

--- a/tests/graphql/getType.test.js
+++ b/tests/graphql/getType.test.js
@@ -1,7 +1,7 @@
 import expect from 'expect'
 import { assign, noop } from 'lodash'
 import { GraphQLEnumType } from 'graphql'
-import { TestType, TestEnum } from '../helpers.js'
+import { TestType, TestEnum, TestDomain } from '../helpers.js'
 import getType from '#/graphql/getType.js'
 
 describe('getType', () => {
@@ -45,7 +45,6 @@ describe('getType', () => {
     expect(graphqlType1a).toNotBe(graphqlType2a)
   })
 
-  // TODO: Move this to a `getType` test file.
   describe('enums', () => {
     const enum_ = new TestEnum({
       name: 'test_enum',
@@ -87,6 +86,12 @@ describe('getType', () => {
         { name: 'TOMATO', value: 'tomato' },
         { name: 'HELLO_WORLD', value: 'hello_world' },
       ].map(variant => assign(variant, { description: noop(), deprecationReason: noop() })))
+    })
+  })
+
+  describe('domains', () => {
+    it('will map a domain type to the underlying type', () => {
+      expect(getType(new TestDomain({ id: 16714, baseTypeId: 23, name: 'an_int' })).name).toEqual('Int')
     })
   })
 })

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -39,6 +39,12 @@ export class TestType extends c.Type {
   }
 }
 
+export class TestDomain extends c.Domain {
+  constructor ({ id = 0, baseTypeId = 0, name = 'test', schema = new TestSchema() } = {}) {
+    super({ id, name, schema, baseType: new TestType(baseTypeId) })
+  }
+}
+
 export class TestEnum extends c.Enum {
   constructor ({ name = 'test', schema = new TestSchema(), ...config } = {}) {
     super({ name, schema, ...config })

--- a/tests/postgres/getCatalog.test.js
+++ b/tests/postgres/getCatalog.test.js
@@ -61,11 +61,16 @@ comment on column b.yo.constant is 'This is constantly 2';
 create type a.letter as enum ('a', 'b', 'c', 'd');
 create type b.color as enum ('red', 'green', 'blue');
 
+create domain a.an_int as integer;
+create domain b.another_int as a.an_int;
+
 create table a.types (
   "bigint" bigint,
   "boolean" boolean,
   "varchar" varchar,
-  "enum" b.color
+  "enum" b.color,
+  "domain" a.an_int,
+  "domain2" b.another_int
 );
 
 create function a.add_1(int, int) returns int as $$ select $1 + $2 $$ language sql immutable;
@@ -193,6 +198,13 @@ describe('getCatalog', function testGetCatalog () {
     expect(catalog.getColumn('a', 'types', 'enum').type.isEnum).toBe(true)
     expect(catalog.getColumn('a', 'types', 'enum').type.name).toEqual('color')
     expect(catalog.getColumn('a', 'types', 'enum').type.variants).toEqual(['red', 'green', 'blue'])
+  })
+
+  it('domain columns will have the base type', () => {
+    expect(catalog.getColumn('a', 'types', 'domain').type.isDomain).toBe(true)
+    expect(catalog.getColumn('a', 'types', 'domain').type.baseType.id).toEqual(23)
+    expect(catalog.getColumn('a', 'types', 'domain2').type.isDomain).toBe(true)
+    expect(catalog.getColumn('a', 'types', 'domain2').type.baseType.id).toEqual(23)
   })
 
   it('will get foreign keys', () => {


### PR DESCRIPTION
Domains are mapped to `GraphQLString` by default, this patch retrieve domain's base type to map them to the proper GraphQL types. Also supports domains of domains.