### PR TITLE
fix(resolve): check for empty string in query values

### DIFF
--- a/examples/kitchen-sink/schema.sql
+++ b/examples/kitchen-sink/schema.sql
@@ -20,7 +20,8 @@ create table another_thing (
   id               serial not null primary key,
   note             text not null,
   published        boolean not null,
-  tags             text[] not null
+  tags             text[] not null,
+  thing_id         int references thing(id) on delete cascade
 );
 
 create function add(a int, b int) returns int as $$
@@ -123,11 +124,6 @@ $$ language plpgsql
 strict
 set search_path from current;
 
-insert into another_thing (note, published, tags) values
-  ('hello', true, '{"a", "b"}'),
-  ('world', true, '{"c", "d"}'),
-  ('foo', false, '{"a"}');
-
 insert into thing (note) values
   ('hello'),
   ('world'),
@@ -146,5 +142,10 @@ insert into relation (a_thing_id, b_thing_id) values
   (3, 5),
   (4, 3),
   (7, 1);
+
+insert into another_thing (note, published, tags, thing_id) values
+  ('hello', true, '{"a", "b"}', 1),
+  ('world', true, '{"c", "d"}', null),
+  ('foo', false, '{"a"}', 2);
 
 commit;

--- a/src/graphql/resolveTableSingle.js
+++ b/src/graphql/resolveTableSingle.js
@@ -44,12 +44,10 @@ const resolveTableSingle = (table, columns, getColumnValues) => {
   const getDataLoader = memoize(client => new DataLoader(async columnValueses => {
     // Query the client with our list of column values and prepared query.
     // Results can be returned in any order.
-    const { rowCount, rows } = await client.queryAsync({
-      name: query.name,
-      text: query.text,
-      // We expect to pass an array of strings with concatenated values.
-      values: [columnValueses.map(columnValues => columnValues.join(','))],
-    })
+
+    // We expect to pass an array of strings with concatenated values.
+    const values = [columnValueses.map(columnValues => (columnValues.join(',') || null))]
+    const { rowCount, rows } = await client.queryAsync({ ...query, values })
 
     // Gets the row from the result set given a few column values.
     let getRow = columnValues => rows.find(row =>

--- a/tests/integration/fixtures/null-foreign-key.graphql
+++ b/tests/integration/fixtures/null-foreign-key.graphql
@@ -1,0 +1,11 @@
+query NullForeignKey {
+  anotherThingNodes { edges { node { ...anotherThing } } }
+}
+
+fragment anotherThing on AnotherThing {
+  id
+  rowId
+  thingByThingId {
+    note
+  }
+}

--- a/tests/integration/fixtures/null-foreign-key.json
+++ b/tests/integration/fixtures/null-foreign-key.json
@@ -1,0 +1,33 @@
+{
+  "data": {
+    "anotherThingNodes": {
+      "edges": [
+        {
+          "node": {
+            "id": "YW5vdGhlcl90aGluZzox",
+            "rowId": 1,
+            "thingByThingId": {
+                "note": "hello"
+            }
+          }
+        },
+        {
+          "node": {
+            "id": "YW5vdGhlcl90aGluZzoy",
+            "rowId": 2,
+            "thingByThingId": null
+          }
+        },
+        {
+          "node": {
+            "id": "YW5vdGhlcl90aGluZzoz",
+            "rowId": 3,
+            "thingByThingId": {
+              "note": "world"
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Foreign keys that are of type `int` are converted to strings [(diff)](https://github.com/calebmer/postgraphql/compare/master...ferdinandsalis:fix-resolve-single?expand=1#diff-0f601b95d640a7e7b90036b6dfb374fbL51). I know this is intended since `any`’s righthand side expects an array expression (if my research was correct). However when a foreign key is null it is interpreted as a string and result in the following error: `error: invalid input syntax for integer`.

I have yet to add a test. Though I am not sure where ☺️.