### PR TITLE
feat(postgres): only show mutations for types that are updatable.

### DIFF
--- a/examples/kitchen-sink/schema.sql
+++ b/examples/kitchen-sink/schema.sql
@@ -24,6 +24,12 @@ create table another_thing (
   thing_id         int references thing(id) on delete cascade
 );
 
+create view non_mutation_view as
+  select 1;
+
+create view mutation_view_for_thing as
+  select * from thing;
+
 create function add(a int, b int) returns int as $$
   select a + b
 $$ language sql

--- a/src/graphql/mutation/createMutationType.js
+++ b/src/graphql/mutation/createMutationType.js
@@ -30,8 +30,15 @@ const createMutationType = schema =>
 
 export default createMutationType
 
-const createMutationFields = table => ({
-  [`insert${upperFirst(camelCase(table.name))}`]: createInsertMutationField(table),
-  [`update${upperFirst(camelCase(table.name))}`]: createUpdateMutationField(table),
-  [`delete${upperFirst(camelCase(table.name))}`]: createDeleteMutationField(table),
-})
+const createMutationFields = table => {
+  const mutations = {}
+
+  if (table.isInsertable)
+    mutations[`insert${upperFirst(camelCase(table.name))}`] = createInsertMutationField(table)
+  if (table.isUpdatable)
+    mutations[`update${upperFirst(camelCase(table.name))}`] = createUpdateMutationField(table)
+  if (table.isDeletable)
+    mutations[`delete${upperFirst(camelCase(table.name))}`] = createDeleteMutationField(table)
+
+  return mutations
+}

--- a/src/postgres/catalog.js
+++ b/src/postgres/catalog.js
@@ -115,15 +115,21 @@ export class Schema {
  * @member {Schema} schema
  * @member {string} name
  * @member {string} description
+ * @member {boolean} isInsertable
+ * @member {boolean} isUpdatable
+ * @member {boolean} isDeletable
  * @member {Column[]} columns
  * @member {ForeignKey[]} foreignKeys
  * @member {ForeignKey[]} reverseForeignKeys
  */
 export class Table {
-  constructor ({ schema, name, description }) {
+  constructor ({ schema, name, description, isInsertable, isUpdatable, isDeletable }) {
     this.schema = schema
     this.name = name
     this.description = description
+    this.isInsertable = isInsertable
+    this.isUpdatable = isUpdatable
+    this.isDeletable = isDeletable
   }
 
   getColumns = once(() => {

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -19,8 +19,8 @@ export class TestSchema extends c.Schema {
 }
 
 export class TestTable extends c.Table {
-  constructor ({ name = 'test', schema = new TestSchema(), ...config } = {}) {
-    super({ name, schema, ...config })
+  constructor ({ name = 'test', schema = new TestSchema(), isInsertable = true, isUpdatable = true, isDeletable = true, ...config } = {}) {
+    super({ name, schema, isInsertable, isUpdatable, isDeletable, ...config })
     this.schema.catalog.addTable(this)
     this.schema.catalog.addColumn(new TestColumn({ table: this, isPrimaryKey: true }))
   }

--- a/tests/integration/fixtures/non-updatable-views-filtered.graphql
+++ b/tests/integration/fixtures/non-updatable-views-filtered.graphql
@@ -1,0 +1,27 @@
+query {
+  noInsertMutation: __type(name: "InsertNonMutationViewPayload") {
+    name
+  }
+  noUpdateMutation: __type(name: "UpdateNonMutationViewPayload") {
+    name
+  }
+  noDeleteMutation: __type(name: "DeleteNonMutationViewPayload") {
+    name
+  }
+
+  insertMutation: __type(name: "InsertMutationViewForThingPayload") {
+    name
+  }
+  updateMutation: __type(name: "UpdateMutationViewForThingPayload") {
+    name
+  }
+  deleteMutation: __type(name: "DeleteMutationViewForThingPayload") {
+    name
+  }
+
+  nonMutationViewNodes(orderBy: COLUMN) {
+    nodes {
+      column
+    }
+  }
+}

--- a/tests/integration/fixtures/non-updatable-views-filtered.json
+++ b/tests/integration/fixtures/non-updatable-views-filtered.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "noInsertMutation": null,
+    "noUpdateMutation": null,
+    "noDeleteMutation": null,
+    "insertMutation": {
+      "name": "InsertMutationViewForThingPayload"
+    },
+    "updateMutation": {
+      "name": "UpdateMutationViewForThingPayload"
+    },
+    "deleteMutation": {
+      "name": "DeleteMutationViewForThingPayload"
+    },
+    "nonMutationViewNodes": {
+      "nodes": [
+        {
+          "column": 1
+        }
+      ]
+    }
+  }
+}

--- a/tests/postgres/getCatalog.test.js
+++ b/tests/postgres/getCatalog.test.js
@@ -55,6 +55,10 @@ create view b.yo as
   from
     a.hello;
 
+create view c.no_update as
+  select
+    (1 + 1) as col1;
+
 comment on view b.yo is 'YOYOYO!!';
 comment on column b.yo.constant is 'This is constantly 2';
 
@@ -205,6 +209,23 @@ describe('getCatalog', function testGetCatalog () {
     expect(catalog.getColumn('a', 'types', 'domain').type.baseType.id).toEqual(23)
     expect(catalog.getColumn('a', 'types', 'domain2').type.isDomain).toBe(true)
     expect(catalog.getColumn('a', 'types', 'domain2').type.baseType.id).toEqual(23)
+  })
+
+  it('contains relation updatable information', () => {
+    // non updatable view
+    expect(catalog.getTable('c', 'no_update').isInsertable).toBe(false)
+    expect(catalog.getTable('c', 'no_update').isUpdatable).toBe(false)
+    expect(catalog.getTable('c', 'no_update').isDeletable).toBe(false)
+
+    // updatable view
+    expect(catalog.getTable('b', 'yo').isInsertable).toBe(true)
+    expect(catalog.getTable('b', 'yo').isUpdatable).toBe(true)
+    expect(catalog.getTable('b', 'yo').isDeletable).toBe(true)
+
+    // table
+    expect(catalog.getTable('a', 'hello').isInsertable).toBe(true)
+    expect(catalog.getTable('a', 'hello').isUpdatable).toBe(true)
+    expect(catalog.getTable('a', 'hello').isDeletable).toBe(true)
   })
 
   it('will get foreign keys', () => {


### PR DESCRIPTION
This is a rework of #53.

I will filter mutations to only show postgres objects that are updatable. This will hide views that are not auto updatable from the mutations graphql schema. 

It will also hide custom types, so the second part of this pr will add in custom types so that they can be used as input and output values of queries and mutations.