### PR TITLE
Fix interval and other type handling

### DIFF
--- a/examples/kitchen-sink/schema.sql
+++ b/examples/kitchen-sink/schema.sql
@@ -25,6 +25,10 @@ create table another_thing (
   thing_id         int references thing(id) on delete cascade
 );
 
+create table anything_goes (
+  interval         interval
+);
+
 create view non_mutation_view as
   select 1;
 

--- a/src/graphql/getType.js
+++ b/src/graphql/getType.js
@@ -7,6 +7,7 @@ import {
   GraphQLEnumType,
 } from 'graphql'
 
+import { types } from 'pg'
 import { memoize, fromPairs, upperFirst, camelCase, snakeCase, toUpper } from 'lodash'
 import createTableType from './createTableType.js'
 
@@ -78,6 +79,12 @@ const postgresToGraphQLTypes = new Map([
   [25, GraphQLString],
   [1043, GraphQLString],
 ])
+
+// Override custom type parsers.
+// TODO: This is a temporary solution.
+types.setTypeParser(600, String)
+types.setTypeParser(718, String)
+types.setTypeParser(1186, String)
 
 /**
  * Gets a GraphQL type for a PostgreSQL type.

--- a/src/graphql/types.js
+++ b/src/graphql/types.js
@@ -1,8 +1,6 @@
 import {
   Kind,
   GraphQLBoolean,
-  GraphQLInt,
-  GraphQLFloat,
   GraphQLID,
   GraphQLNonNull,
   GraphQLScalarType,
@@ -108,52 +106,19 @@ export const DateType = createStringScalarType({
   description: 'Some time value',
 })
 
-export const PointType = new GraphQLObjectType({
+export const PointType = createStringScalarType({
   name: 'Point',
   description: 'A geometric point on a plane',
-  fields: {
-    x: {
-      type: new GraphQLNonNull(GraphQLFloat),
-      description: 'The x coordinate of the point',
-    },
-    y: {
-      type: new GraphQLNonNull(GraphQLFloat),
-      description: 'The y coordinate of the point',
-    },
-  },
 })
 
-export const CircleType = new GraphQLObjectType({
+export const CircleType = createStringScalarType({
   name: 'Circle',
   description: 'Some circle on a plane made of a point and a radius',
-  fields: {
-    x: {
-      type: new GraphQLNonNull(GraphQLFloat),
-      description: 'The x coordinate of the circle',
-    },
-    y: {
-      type: new GraphQLNonNull(GraphQLFloat),
-      description: 'The y coordinate of the circle',
-    },
-    radius: {
-      type: new GraphQLNonNull(GraphQLFloat),
-      description: 'The radius of the circle',
-    },
-  },
 })
 
-export const IntervalType = new GraphQLObjectType({
+export const IntervalType = createStringScalarType({
   name: 'Interval',
   description: 'Some time span',
-  fields: {
-    milliseconds: { type: GraphQLInt },
-    seconds: { type: GraphQLInt },
-    minutes: { type: GraphQLInt },
-    hours: { type: GraphQLInt },
-    days: { type: GraphQLInt },
-    months: { type: GraphQLInt },
-    years: { type: GraphQLInt },
-  },
 })
 
 export const JSONType = createStringScalarType({


### PR DESCRIPTION
This is a hotfix to solve #88. I’m working on some refactors to the codebase which would make the “correct” solution possible. For now I want to deploy a fix as this is crashing APIs.

The correct implementation would be to split the type into both a `GraphQLObjectType` and a `GraphQLInputObjectType`.