### PR TITLE
fix(graphql): non-unique cursors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   - "5"
 
 addons:
-  postgresql: "9.4"
+  postgresql: "9.5"
 
 env:
   TEST_DB: postgres://localhost:5432/travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   - "5"
 
 addons:
-  postgresql: "9.5"
+  postgresql: "9.4"
 
 env:
   TEST_DB: postgres://localhost:5432/travis

--- a/examples/kitchen-sink/schema.sql
+++ b/examples/kitchen-sink/schema.sql
@@ -25,7 +25,10 @@ create table another_thing (
   thing_id         int references thing(id) on delete cascade
 );
 
+-- Do not add a primary key to this table.
 create table anything_goes (
+  foo              int,
+  bar              int,
   interval         interval
 );
 
@@ -158,5 +161,10 @@ insert into another_thing (note, published, tags, thing_id) values
   ('hello', true, '{"a", "b"}', 1),
   ('world', true, '{"c", "d"}', null),
   ('foo', false, '{"a"}', 2);
+
+insert into anything_goes (foo, bar) values
+  (1, 2),
+  (2, 3),
+  (3, 4);
 
 commit;

--- a/src/graphql/resolveConnection.js
+++ b/src/graphql/resolveConnection.js
@@ -74,7 +74,10 @@ const resolveConnection = (
       })`
 
       const cursorCompareRHS = `(${
-        [null, ...primaryKeyNoOrderBy].map((x, i) => `$${i + 1}`).join(', ')
+        // Here we only want to create a string of placeholders: `$1, $2, $3`
+        // etc. So we create an array of nulls of the appropriate length and
+        // then use the index (`i`) to generate the actual placeholder.
+        Array(1 + primaryKeyNoOrderBy.length).fill(null).map((x, i) => `$${i + 1}`).join(', ')
       })`
 
       sql.add(`${cursorCompareLHS} ${operator} ${cursorCompareRHS}`, [cursor.value, ...cursor.primaryKey])

--- a/src/graphql/resolveConnection.js
+++ b/src/graphql/resolveConnection.js
@@ -8,6 +8,7 @@ const resolveConnection = (
   getFromClause = constant(table.getIdentifier()),
 ) => {
   const columns = table.getColumns()
+  const primaryKey = table.getPrimaryKeys()
 
   return (source, args, { client }) => {
     const { orderBy: orderByName, first, last, after, before, offset, descending, ...conditions } = args
@@ -28,7 +29,10 @@ const resolveConnection = (
     const fromClause = getFromClause(source, args)
 
     // Get the cursor value for a row using the `orderBy` column.
-    const getRowCursorValue = row => row[orderBy.name] || ''
+    const getRowCursorValue = row => ({
+      value: row[orderBy.name] || '',
+      primaryKey: primaryKey.map(({ name }) => row[name]),
+    })
 
     // Transforms object keys (which are field names) into column names.
     const getWhereClause = once(() => {
@@ -51,14 +55,36 @@ const resolveConnection = (
       return sql
     })
 
+    // Gets the condition for filtering our result set using a cursor.
+    const getCursorCondition = (cursor, operator) => {
+      const sql = new SQLBuilder()
+
+      if (primaryKey.length === 1 && primaryKey[0].name === orderBy.name)
+        return sql.add(`"${orderBy.name}" ${operator} $1`, [cursor.value])
+
+      const cursorCompareLHS = `(${
+        [orderBy.name, ...primaryKey.map(({ name }) => name)]
+          .map(name => `"${name}"`)
+          .join(', ')
+      })`
+
+      const cursorCompareRHS = `(${
+        [null, ...primaryKey].map((x, i) => `$${i + 1}`).join(', ')
+      })`
+
+      sql.add(`${cursorCompareLHS} ${operator} ${cursorCompareRHS}`, [cursor.value, ...cursor.primaryKey])
+
+      return sql
+    }
+
     const getRows = once(async () => {
       // Start our query.
       const sql = new SQLBuilder().add('select * from').add(fromClause).add('where')
 
       // Add the conditions for `after` and `before` which will narrow our
       // range.
-      if (before) sql.add(`"${orderBy.name}" < $1 and`, [before])
-      if (after) sql.add(`"${orderBy.name}" > $1 and`, [after])
+      if (before) sql.add(getCursorCondition(before, '<')).add('and')
+      if (after) sql.add(getCursorCondition(after, '>')).add('and')
 
       // Add the conditions…
       sql.add(getWhereClause())
@@ -67,7 +93,13 @@ const resolveConnection = (
       // If a `last` argument was defined we are querying from the bottom so we
       // need to flip our order.
       const actuallyDescending = last ? !descending : descending
-      sql.add(`order by "${orderBy.name}" ${actuallyDescending ? 'desc' : 'asc'}`)
+
+      const orderings = [
+        `"${orderBy.name}" ${actuallyDescending ? 'desc' : 'asc'}`,
+        ...primaryKey.map(({ name }) => `"${name}" ${last ? 'desc' : 'asc'}`),
+      ].join(', ')
+
+      sql.add(`order by ${orderings}`)
 
       // Set the correct range.
       if (first) sql.add('limit $1', [first])
@@ -119,7 +151,9 @@ const resolveConnection = (
                 new SQLBuilder()
                 .add('select null from')
                 .add(fromClause)
-                .add(`where "${orderBy.name}" ${descending ? '<' : '>'} $1 and`, [endCursor])
+                .add('where')
+                .add(getCursorCondition(endCursor, descending ? '<' : '>'))
+                .add('and')
                 .add(getWhereClause())
                 .add('limit 1')
               )
@@ -142,7 +176,9 @@ const resolveConnection = (
                 new SQLBuilder()
                 .add('select null from')
                 .add(fromClause)
-                .add(`where "${orderBy.name}" ${descending ? '>' : '<'} $1 and`, [startCursor])
+                .add('where')
+                .add(getCursorCondition(startCursor, descending ? '>' : '<'))
+                .add('and')
                 .add(getWhereClause())
                 .add('limit 1')
               )

--- a/src/graphql/types.js
+++ b/src/graphql/types.js
@@ -55,13 +55,21 @@ export const NodeType =
  * Connection Types
  * ========================================================================= */
 
+const serializeCursor = cursor =>
+  toBase64(JSON.stringify([cursor.primaryKey, cursor.value]))
+
+const deserializeCursor = serializedCursor => {
+  const [primaryKey, value] = JSON.parse(fromBase64(serializedCursor))
+  return { primaryKey, value }
+}
+
 export const CursorType =
   new GraphQLScalarType({
     name: 'Cursor',
     description: 'An opaque base64 encoded string describing a location in a list of items.',
-    serialize: toBase64,
-    parseValue: fromBase64,
-    parseLiteral: ast => (ast.kind === Kind.STRING ? fromBase64(ast.value) : null),
+    serialize: serializeCursor,
+    parseValue: deserializeCursor,
+    parseLiteral: ast => (ast.kind === Kind.STRING ? deserializeCursor(ast.value) : null),
   })
 
 export const PageInfoType =

--- a/tests/integration/fixtures/mutation-insert.json
+++ b/tests/integration/fixtures/mutation-insert.json
@@ -8,19 +8,19 @@
         "note": "a"
       },
       "withArg": {
-        "cursor": "OA==",
+        "cursor": "W251bGwsbnVsbF0=",
         "node": {
           "id": "dGhpbmc6OA==",
-          "note": "a",
-          "rowId": 8
+          "rowId": 8,
+          "note": "a"
         }
       },
       "withoutArg": {
-        "cursor": "OA==",
+        "cursor": "W251bGwsbnVsbF0=",
         "node": {
           "id": "dGhpbmc6OA==",
-          "note": "a",
-          "rowId": 8
+          "rowId": 8,
+          "note": "a"
         }
       }
     },
@@ -32,19 +32,19 @@
         "note": "b"
       },
       "withArg": {
-        "cursor": "OQ==",
+        "cursor": "W251bGwsbnVsbF0=",
         "node": {
           "id": "dGhpbmc6OQ==",
-          "note": "b",
-          "rowId": 9
+          "rowId": 9,
+          "note": "b"
         }
       },
       "withoutArg": {
-        "cursor": "OQ==",
+        "cursor": "W251bGwsbnVsbF0=",
         "node": {
           "id": "dGhpbmc6OQ==",
-          "note": "b",
-          "rowId": 9
+          "rowId": 9,
+          "note": "b"
         }
       }
     },
@@ -65,19 +65,19 @@
         }
       },
       "relationEdge": {
-        "cursor": "OA==",
+        "cursor": "W251bGwsbnVsbF0=",
         "node": {
           "aThingId": 8,
           "bThingId": 9,
           "thingByAThingId": {
             "id": "dGhpbmc6OA==",
-            "note": "a",
-            "rowId": 8
+            "rowId": 8,
+            "note": "a"
           },
           "thingByBThingId": {
             "id": "dGhpbmc6OQ==",
-            "note": "b",
-            "rowId": 9
+            "rowId": 9,
+            "note": "b"
           }
         }
       }

--- a/tests/integration/fixtures/nodes.graphql
+++ b/tests/integration/fixtures/nodes.graphql
@@ -16,10 +16,10 @@ query Nodes {
   e: thingNodes(orderBy: NOTE, descending: true) {
     edges { cursor, node { ...thing } }
   }
-  f: thingNodes(before: "NQ==") {
+  f: thingNodes(before: "W1s1XSw1XQ==") {
     nodes { ...thing }
   }
-  g: thingNodes(after: "NA==") {
+  g: thingNodes(after: "W1s0XSw0XQ==") {
     nodes { ...thing }
   }
 }

--- a/tests/integration/fixtures/nodes.graphql
+++ b/tests/integration/fixtures/nodes.graphql
@@ -22,6 +22,27 @@ query Nodes {
   g: thingNodes(after: "W1s0XSw0XQ==") {
     nodes { ...thing }
   }
+  # Test a table that does not have a primary key.
+  h: anythingGoesNodes(orderBy: FOO, after: "W1tdLDFd") {
+    edges {
+      cursor
+      node {
+        foo
+        bar
+      }
+    }
+  }
+  # If we only checked cursor values and not primary keys as well, this would
+  # fail.
+  i: relationNodes(orderBy: A_THING_ID, after: "W1sxLDJdLDFd") {
+    edges {
+      cursor
+      node {
+        aThingId
+        bThingId
+      }
+    }
+  }
 }
 
 fragment thing on Thing {

--- a/tests/integration/fixtures/nodes.graphql
+++ b/tests/integration/fixtures/nodes.graphql
@@ -16,14 +16,20 @@ query Nodes {
   e: thingNodes(orderBy: NOTE, descending: true) {
     edges { cursor, node { ...thing } }
   }
-  f: thingNodes(before: "W1s1XSw1XQ==") {
+  f: thingNodes(before: "W1tdLDVd") {
     nodes { ...thing }
   }
-  g: thingNodes(after: "W1s0XSw0XQ==") {
+  g: thingNodes(after: "W1tdLDRd") {
     nodes { ...thing }
+  }
+  h: thingNodes(orderBy: LUCKY_NUMBER, after: "W1s2XSw2Nl0=") {
+    edges {
+      cursor
+      node { ...thing, luckyNumber }
+    }
   }
   # Test a table that does not have a primary key.
-  h: anythingGoesNodes(orderBy: FOO, after: "W1tdLDFd") {
+  i: anythingGoesNodes(orderBy: FOO, after: "W1tdLDFd") {
     edges {
       cursor
       node {
@@ -34,7 +40,7 @@ query Nodes {
   }
   # If we only checked cursor values and not primary keys as well, this would
   # fail.
-  i: relationNodes(orderBy: A_THING_ID, after: "W1sxLDJdLDFd") {
+  j: relationNodes(orderBy: A_THING_ID, after: "W1syXSwxXQ==") {
     edges {
       cursor
       node {

--- a/tests/integration/fixtures/nodes.json
+++ b/tests/integration/fixtures/nodes.json
@@ -43,12 +43,12 @@
       "pageInfo": {
         "hasNextPage": true,
         "hasPreviousPage": false,
-        "startCursor": "MQ==",
-        "endCursor": "Mg=="
+        "startCursor": "W1sxXSwxXQ==",
+        "endCursor": "W1syXSwyXQ=="
       },
       "edges": [
         {
-          "cursor": "MQ==",
+          "cursor": "W1sxXSwxXQ==",
           "node": {
             "id": "dGhpbmc6MQ==",
             "rowId": 1,
@@ -56,7 +56,7 @@
           }
         },
         {
-          "cursor": "Mg==",
+          "cursor": "W1syXSwyXQ==",
           "node": {
             "id": "dGhpbmc6Mg==",
             "rowId": 2,
@@ -69,8 +69,8 @@
       "pageInfo": {
         "hasNextPage": false,
         "hasPreviousPage": true,
-        "startCursor": "Ng==",
-        "endCursor": "Nw=="
+        "startCursor": "W1s2XSw2XQ==",
+        "endCursor": "W1s3XSw3XQ=="
       },
       "nodes": [
         {
@@ -127,7 +127,7 @@
     "e": {
       "edges": [
         {
-          "cursor": "d29ybGQ=",
+          "cursor": "W1syXSwid29ybGQiXQ==",
           "node": {
             "id": "dGhpbmc6Mg==",
             "rowId": 2,
@@ -135,7 +135,7 @@
           }
         },
         {
-          "cursor": "cXV4",
+          "cursor": "W1s3XSwicXV4Il0=",
           "node": {
             "id": "dGhpbmc6Nw==",
             "rowId": 7,
@@ -143,7 +143,7 @@
           }
         },
         {
-          "cursor": "aGVsbG8=",
+          "cursor": "W1sxXSwiaGVsbG8iXQ==",
           "node": {
             "id": "dGhpbmc6MQ==",
             "rowId": 1,
@@ -151,7 +151,7 @@
           }
         },
         {
-          "cursor": "Zm9v",
+          "cursor": "W1szXSwiZm9vIl0=",
           "node": {
             "id": "dGhpbmc6Mw==",
             "rowId": 3,
@@ -159,7 +159,7 @@
           }
         },
         {
-          "cursor": "YnV4",
+          "cursor": "W1s2XSwiYnV4Il0=",
           "node": {
             "id": "dGhpbmc6Ng==",
             "rowId": 6,
@@ -167,7 +167,7 @@
           }
         },
         {
-          "cursor": "YmF6",
+          "cursor": "W1s1XSwiYmF6Il0=",
           "node": {
             "id": "dGhpbmc6NQ==",
             "rowId": 5,
@@ -175,7 +175,7 @@
           }
         },
         {
-          "cursor": "YmFy",
+          "cursor": "W1s0XSwiYmFyIl0=",
           "node": {
             "id": "dGhpbmc6NA==",
             "rowId": 4,

--- a/tests/integration/fixtures/nodes.json
+++ b/tests/integration/fixtures/nodes.json
@@ -43,12 +43,12 @@
       "pageInfo": {
         "hasNextPage": true,
         "hasPreviousPage": false,
-        "startCursor": "W1sxXSwxXQ==",
-        "endCursor": "W1syXSwyXQ=="
+        "startCursor": "W1tdLDFd",
+        "endCursor": "W1tdLDJd"
       },
       "edges": [
         {
-          "cursor": "W1sxXSwxXQ==",
+          "cursor": "W1tdLDFd",
           "node": {
             "id": "dGhpbmc6MQ==",
             "rowId": 1,
@@ -56,7 +56,7 @@
           }
         },
         {
-          "cursor": "W1syXSwyXQ==",
+          "cursor": "W1tdLDJd",
           "node": {
             "id": "dGhpbmc6Mg==",
             "rowId": 2,
@@ -69,8 +69,8 @@
       "pageInfo": {
         "hasNextPage": false,
         "hasPreviousPage": true,
-        "startCursor": "W1s2XSw2XQ==",
-        "endCursor": "W1s3XSw3XQ=="
+        "startCursor": "W1tdLDZd",
+        "endCursor": "W1tdLDdd"
       },
       "nodes": [
         {
@@ -230,6 +230,28 @@
     "h": {
       "edges": [
         {
+          "cursor": "W1s1XSw5OF0=",
+          "node": {
+            "id": "dGhpbmc6NQ==",
+            "rowId": 5,
+            "note": "baz",
+            "luckyNumber": 98
+          }
+        },
+        {
+          "cursor": "W1syXSw0MjBd",
+          "node": {
+            "id": "dGhpbmc6Mg==",
+            "rowId": 2,
+            "note": "world",
+            "luckyNumber": 420
+          }
+        }
+      ]
+    },
+    "i": {
+      "edges": [
+        {
           "cursor": "W1tdLDJd",
           "node": {
             "foo": 2,
@@ -245,59 +267,52 @@
         }
       ]
     },
-    "i": {
+    "j": {
       "edges": [
         {
-          "cursor": "W1sxLDJdLDFd",
-          "node": {
-            "aThingId": 1,
-            "bThingId": 2
-          }
-        },
-        {
-          "cursor": "W1sxLDNdLDFd",
+          "cursor": "W1szXSwxXQ==",
           "node": {
             "aThingId": 1,
             "bThingId": 3
           }
         },
         {
-          "cursor": "W1sxLDddLDFd",
+          "cursor": "W1s3XSwxXQ==",
           "node": {
             "aThingId": 1,
             "bThingId": 7
           }
         },
         {
-          "cursor": "W1syLDNdLDJd",
+          "cursor": "W1szXSwyXQ==",
           "node": {
             "aThingId": 2,
             "bThingId": 3
           }
         },
         {
-          "cursor": "W1szLDRdLDNd",
+          "cursor": "W1s0XSwzXQ==",
           "node": {
             "aThingId": 3,
             "bThingId": 4
           }
         },
         {
-          "cursor": "W1szLDVdLDNd",
+          "cursor": "W1s1XSwzXQ==",
           "node": {
             "aThingId": 3,
             "bThingId": 5
           }
         },
         {
-          "cursor": "W1s0LDNdLDRd",
+          "cursor": "W1szXSw0XQ==",
           "node": {
             "aThingId": 4,
             "bThingId": 3
           }
         },
         {
-          "cursor": "W1s3LDFdLDdd",
+          "cursor": "W1sxXSw3XQ==",
           "node": {
             "aThingId": 7,
             "bThingId": 1

--- a/tests/integration/fixtures/nodes.json
+++ b/tests/integration/fixtures/nodes.json
@@ -226,6 +226,84 @@
           "note": "qux"
         }
       ]
+    },
+    "h": {
+      "edges": [
+        {
+          "cursor": "W1tdLDJd",
+          "node": {
+            "foo": 2,
+            "bar": 3
+          }
+        },
+        {
+          "cursor": "W1tdLDNd",
+          "node": {
+            "foo": 3,
+            "bar": 4
+          }
+        }
+      ]
+    },
+    "i": {
+      "edges": [
+        {
+          "cursor": "W1sxLDJdLDFd",
+          "node": {
+            "aThingId": 1,
+            "bThingId": 2
+          }
+        },
+        {
+          "cursor": "W1sxLDNdLDFd",
+          "node": {
+            "aThingId": 1,
+            "bThingId": 3
+          }
+        },
+        {
+          "cursor": "W1sxLDddLDFd",
+          "node": {
+            "aThingId": 1,
+            "bThingId": 7
+          }
+        },
+        {
+          "cursor": "W1syLDNdLDJd",
+          "node": {
+            "aThingId": 2,
+            "bThingId": 3
+          }
+        },
+        {
+          "cursor": "W1szLDRdLDNd",
+          "node": {
+            "aThingId": 3,
+            "bThingId": 4
+          }
+        },
+        {
+          "cursor": "W1szLDVdLDNd",
+          "node": {
+            "aThingId": 3,
+            "bThingId": 5
+          }
+        },
+        {
+          "cursor": "W1s0LDNdLDRd",
+          "node": {
+            "aThingId": 4,
+            "bThingId": 3
+          }
+        },
+        {
+          "cursor": "W1s3LDFdLDdd",
+          "node": {
+            "aThingId": 7,
+            "bThingId": 1
+          }
+        }
+      ]
     }
   }
 }

--- a/tests/integration/fixtures/pagination.graphql
+++ b/tests/integration/fixtures/pagination.graphql
@@ -8,17 +8,17 @@ query Pagination {
   g: thingNodes(first: 1, offset: 1) { ...page }
   h: thingNodes(first: 4, offset: 5) { ...page }
   i: thingNodes(first: 4, offset: 5) { ...page }
-  j: thingNodes(after: "NQ==") { ...page }
-  k: thingNodes(after: "Nw==") { ...page }
-  l: thingNodes(before: "Mw==") { ...page }
-  m: thingNodes(before: "MQ==") { ...page }
-  n: thingNodes(after: "NQ==", before: "NQ==") { ...page }
-  o: thingNodes(after: "Mg==", before: "Ng==") { ...page }
-  p: thingNodes(after: "NA==", first: 2) { ...page }
-  q: thingNodes(after: "NA==", first: 40) { ...page }
-  r: thingNodes(before: "NA==", last: 2) { ...page }
-  s: thingNodes(before: "NA==", first: 2) { ...page }
-  t: thingNodes(before: "NA==", last: 40) { ...page }
+  j: thingNodes(after: "W1s1XSw1XQ==") { ...page }
+  k: thingNodes(after: "W1s3XSw3XQ==") { ...page }
+  l: thingNodes(before: "W1szXSwzXQ==") { ...page }
+  m: thingNodes(before: "W1sxXSwxXQ==") { ...page }
+  n: thingNodes(after: "W1s1XSw1XQ==", before: "W1s1XSw1XQ==") { ...page }
+  o: thingNodes(after: "W1syXSwyXQ==", before: "W1s2XSw2XQ==") { ...page }
+  p: thingNodes(after: "W1s0XSw0XQ==", first: 2) { ...page }
+  q: thingNodes(after: "W1s0XSw0XQ==", first: 40) { ...page }
+  r: thingNodes(before: "W1s0XSw0XQ==", last: 2) { ...page }
+  s: thingNodes(before: "W1s0XSw0XQ==", first: 2) { ...page }
+  t: thingNodes(before: "W1s0XSw0XQ==", last: 40) { ...page }
 }
 
 fragment page on ThingConnection {

--- a/tests/integration/fixtures/pagination.graphql
+++ b/tests/integration/fixtures/pagination.graphql
@@ -8,17 +8,17 @@ query Pagination {
   g: thingNodes(first: 1, offset: 1) { ...page }
   h: thingNodes(first: 4, offset: 5) { ...page }
   i: thingNodes(first: 4, offset: 5) { ...page }
-  j: thingNodes(after: "W1s1XSw1XQ==") { ...page }
-  k: thingNodes(after: "W1s3XSw3XQ==") { ...page }
-  l: thingNodes(before: "W1szXSwzXQ==") { ...page }
-  m: thingNodes(before: "W1sxXSwxXQ==") { ...page }
-  n: thingNodes(after: "W1s1XSw1XQ==", before: "W1s1XSw1XQ==") { ...page }
-  o: thingNodes(after: "W1syXSwyXQ==", before: "W1s2XSw2XQ==") { ...page }
-  p: thingNodes(after: "W1s0XSw0XQ==", first: 2) { ...page }
-  q: thingNodes(after: "W1s0XSw0XQ==", first: 40) { ...page }
-  r: thingNodes(before: "W1s0XSw0XQ==", last: 2) { ...page }
-  s: thingNodes(before: "W1s0XSw0XQ==", first: 2) { ...page }
-  t: thingNodes(before: "W1s0XSw0XQ==", last: 40) { ...page }
+  j: thingNodes(after: "W1tdLDVd") { ...page }
+  k: thingNodes(after: "W1tdLDdd") { ...page }
+  l: thingNodes(before: "W1tdLDNd") { ...page }
+  m: thingNodes(before: "W1tdLDFd") { ...page }
+  n: thingNodes(after: "W1tdLDVd", before: "W1tdLDVd") { ...page }
+  o: thingNodes(after: "W1tdLDJd", before: "W1tdLDZd") { ...page }
+  p: thingNodes(after: "W1tdLDRd", first: 2) { ...page }
+  q: thingNodes(after: "W1tdLDRd", first: 40) { ...page }
+  r: thingNodes(before: "W1tdLDRd", last: 2) { ...page }
+  s: thingNodes(before: "W1tdLDRd", first: 2) { ...page }
+  t: thingNodes(before: "W1tdLDRd", last: 40) { ...page }
 }
 
 fragment page on ThingConnection {

--- a/tests/integration/fixtures/procedure-query.graphql
+++ b/tests/integration/fixtures/procedure-query.graphql
@@ -41,10 +41,19 @@ query Procedure {
       ...thing
     }
   }
-  k: thingsModulo(after: "W1sxXSwxXQ==", before: "W1s3XSw3XQ==") {
+  k: thingsModulo(after: "W1tdLDFd", before: "W1tdLDdd") {
 		pageInfo { ...pageInfo }
     nodes {
       ...thing
+    }
+  }
+  l: thingsModulo(orderBy: LUCKY_NUMBER, after: "W1s3XSwwXQ==", before: "W1s1XSw5OF0=") {
+    edges {
+      cursor
+      node {
+        ...thing
+        luckyNumber
+      }
     }
   }
 }

--- a/tests/integration/fixtures/procedure-query.graphql
+++ b/tests/integration/fixtures/procedure-query.graphql
@@ -41,7 +41,7 @@ query Procedure {
       ...thing
     }
   }
-  k: thingsModulo(after: "MQ==", before: "Nw==") {
+  k: thingsModulo(after: "W1sxXSwxXQ==", before: "W1s3XSw3XQ==") {
 		pageInfo { ...pageInfo }
     nodes {
       ...thing

--- a/tests/integration/fixtures/procedure-query.json
+++ b/tests/integration/fixtures/procedure-query.json
@@ -21,7 +21,7 @@
             "totalCount": 3,
             "edges": [
               {
-                "cursor": "Mg==",
+                "cursor": "W1syXSwyXQ==",
                 "node": {
                   "id": "dGhpbmc6Mg==",
                   "rowId": 2,
@@ -41,7 +41,7 @@
             "totalCount": 1,
             "edges": [
               {
-                "cursor": "Mw==",
+                "cursor": "W1szXSwzXQ==",
                 "node": {
                   "id": "dGhpbmc6Mw==",
                   "rowId": 3,
@@ -61,7 +61,7 @@
             "totalCount": 2,
             "edges": [
               {
-                "cursor": "NA==",
+                "cursor": "W1s0XSw0XQ==",
                 "node": {
                   "id": "dGhpbmc6NA==",
                   "rowId": 4,
@@ -81,7 +81,7 @@
             "totalCount": 1,
             "edges": [
               {
-                "cursor": "Mw==",
+                "cursor": "W1szXSwzXQ==",
                 "node": {
                   "id": "dGhpbmc6Mw==",
                   "rowId": 3,
@@ -123,7 +123,7 @@
             "totalCount": 1,
             "edges": [
               {
-                "cursor": "MQ==",
+                "cursor": "W1sxXSwxXQ==",
                 "node": {
                   "id": "dGhpbmc6MQ==",
                   "rowId": 1,
@@ -169,7 +169,7 @@
       ],
       "edges": [
         {
-          "cursor": "MQ==",
+          "cursor": "W1sxXSwxXQ==",
           "node": {
             "id": "dGhpbmc6MQ==",
             "rowId": 1,
@@ -177,7 +177,7 @@
           }
         },
         {
-          "cursor": "Mw==",
+          "cursor": "W1szXSwzXQ==",
           "node": {
             "id": "dGhpbmc6Mw==",
             "rowId": 3,
@@ -185,7 +185,7 @@
           }
         },
         {
-          "cursor": "NQ==",
+          "cursor": "W1s1XSw1XQ==",
           "node": {
             "id": "dGhpbmc6NQ==",
             "rowId": 5,
@@ -193,7 +193,7 @@
           }
         },
         {
-          "cursor": "Nw==",
+          "cursor": "W1s3XSw3XQ==",
           "node": {
             "id": "dGhpbmc6Nw==",
             "rowId": 7,
@@ -225,8 +225,8 @@
       "pageInfo": {
         "hasNextPage": true,
         "hasPreviousPage": false,
-        "startCursor": "MQ==",
-        "endCursor": "Mw=="
+        "startCursor": "W1sxXSwxXQ==",
+        "endCursor": "W1szXSwzXQ=="
       },
       "nodes": [
         {
@@ -245,8 +245,8 @@
       "pageInfo": {
         "hasNextPage": true,
         "hasPreviousPage": true,
-        "startCursor": "Mw==",
-        "endCursor": "NQ=="
+        "startCursor": "W1szXSwzXQ==",
+        "endCursor": "W1s1XSw1XQ=="
       },
       "nodes": [
         {

--- a/tests/integration/fixtures/procedure-query.json
+++ b/tests/integration/fixtures/procedure-query.json
@@ -21,7 +21,7 @@
             "totalCount": 3,
             "edges": [
               {
-                "cursor": "W1syXSwyXQ==",
+                "cursor": "W1tdLDJd",
                 "node": {
                   "id": "dGhpbmc6Mg==",
                   "rowId": 2,
@@ -41,7 +41,7 @@
             "totalCount": 1,
             "edges": [
               {
-                "cursor": "W1szXSwzXQ==",
+                "cursor": "W1tdLDNd",
                 "node": {
                   "id": "dGhpbmc6Mw==",
                   "rowId": 3,
@@ -61,7 +61,7 @@
             "totalCount": 2,
             "edges": [
               {
-                "cursor": "W1s0XSw0XQ==",
+                "cursor": "W1tdLDRd",
                 "node": {
                   "id": "dGhpbmc6NA==",
                   "rowId": 4,
@@ -81,7 +81,7 @@
             "totalCount": 1,
             "edges": [
               {
-                "cursor": "W1szXSwzXQ==",
+                "cursor": "W1tdLDNd",
                 "node": {
                   "id": "dGhpbmc6Mw==",
                   "rowId": 3,
@@ -123,7 +123,7 @@
             "totalCount": 1,
             "edges": [
               {
-                "cursor": "W1sxXSwxXQ==",
+                "cursor": "W1tdLDFd",
                 "node": {
                   "id": "dGhpbmc6MQ==",
                   "rowId": 1,
@@ -169,7 +169,7 @@
       ],
       "edges": [
         {
-          "cursor": "W1sxXSwxXQ==",
+          "cursor": "W1tdLDFd",
           "node": {
             "id": "dGhpbmc6MQ==",
             "rowId": 1,
@@ -177,7 +177,7 @@
           }
         },
         {
-          "cursor": "W1szXSwzXQ==",
+          "cursor": "W1tdLDNd",
           "node": {
             "id": "dGhpbmc6Mw==",
             "rowId": 3,
@@ -185,7 +185,7 @@
           }
         },
         {
-          "cursor": "W1s1XSw1XQ==",
+          "cursor": "W1tdLDVd",
           "node": {
             "id": "dGhpbmc6NQ==",
             "rowId": 5,
@@ -193,7 +193,7 @@
           }
         },
         {
-          "cursor": "W1s3XSw3XQ==",
+          "cursor": "W1tdLDdd",
           "node": {
             "id": "dGhpbmc6Nw==",
             "rowId": 7,
@@ -225,8 +225,8 @@
       "pageInfo": {
         "hasNextPage": true,
         "hasPreviousPage": false,
-        "startCursor": "W1sxXSwxXQ==",
-        "endCursor": "W1szXSwzXQ=="
+        "startCursor": "W1tdLDFd",
+        "endCursor": "W1tdLDNd"
       },
       "nodes": [
         {
@@ -245,8 +245,8 @@
       "pageInfo": {
         "hasNextPage": true,
         "hasPreviousPage": true,
-        "startCursor": "W1szXSwzXQ==",
-        "endCursor": "W1s1XSw1XQ=="
+        "startCursor": "W1tdLDNd",
+        "endCursor": "W1tdLDVd"
       },
       "nodes": [
         {
@@ -258,6 +258,28 @@
           "id": "dGhpbmc6NQ==",
           "rowId": 5,
           "note": "baz"
+        }
+      ]
+    },
+    "l": {
+      "edges": [
+        {
+          "cursor": "W1szXSwxMl0=",
+          "node": {
+            "id": "dGhpbmc6Mw==",
+            "rowId": 3,
+            "note": "foo",
+            "luckyNumber": 12
+          }
+        },
+        {
+          "cursor": "W1sxXSw0Ml0=",
+          "node": {
+            "id": "dGhpbmc6MQ==",
+            "rowId": 1,
+            "note": "hello",
+            "luckyNumber": 42
+          }
         }
       ]
     }


### PR DESCRIPTION
Fixes non-unique cursors by adding values for the primary key to the cursor and using that to select.

Closes https://github.com/calebmer/postgraphql/issues/93