### PR TITLE
feat(server): Allow for custom logging middleware to be passed to server

### DIFF
--- a/docs/library.md
+++ b/docs/library.md
@@ -40,9 +40,11 @@ Arguments include:
   - `secret`: The secret for your application. This enables PostGraphQL’s authorization features. Make it something secure and obscure!
   - `development`: Enables development features like GraphiQL and more descriptive error formatting.
   - `log`: If true, PostGraphQL will log every request using the dev style of [morgan][].
+  - `logger`: Custom logger middleware to use instead of the default. e.g. [express-winston]
 
 [connect]: https://www.npmjs.com/connect
 [express]: https://www.npmjs.com/express
+[express-winston]: https://www.npmjs.com/express-winston
 [graphql/express-graphql#82]: https://github.com/graphql/express-graphql/pull/82
 [`pg`]: https://www.npmjs.com/pg
 [morgan]: https://www.npmjs.com/morgan

--- a/src/createServer.js
+++ b/src/createServer.js
@@ -3,7 +3,7 @@ import { forEach } from 'lodash'
 import Express from 'express'
 import onFinished from 'on-finished'
 import { Forbidden, BadRequest } from 'http-errors'
-import logger from 'morgan'
+import morgan from 'morgan'
 import favicon from 'serve-favicon'
 import finalHandler from 'finalhandler'
 import jwt from 'jsonwebtoken'
@@ -19,6 +19,8 @@ import graphqlHTTP from 'express-graphql'
  * @param {Object} options.pgConfig
  * @param {string} options.route
  * @param {boolean} options.development
+ * @param {boolean} options.log - Whether to enable logging.
+ * @param {Object} options.logger - Custom logging middleware.
  * @returns {Server}
  */
 const createServer = ({
@@ -29,12 +31,13 @@ const createServer = ({
   secret,
   development = true,
   log = true,
+  logger = morgan(development ? 'dev' : 'common'),
 }) => {
   const server = new Express()
 
   server.disable('x-powered-by')
 
-  if (log) server.use(logger(development ? 'dev' : 'common'))
+  if (log) server.use(logger)
   server.use(favicon(path.join(__dirname, '../assets/favicon.ico')))
 
   // Enabels CORS. See [this][1] flowchart for an explanation of how CORS


### PR DESCRIPTION
I have custom log formats configured for all my servers but PostGraphQL was dumping out it's own format that I could not configure (or change to winston as I wanted).

I've added a `logger` option to the `createServer` interface so you are free to pass in your own logging middleware, falling back to the original `morgan` option.