### PR TITLE
Fix JSON type serialization

### DIFF
--- a/examples/kitchen-sink/schema.sql
+++ b/examples/kitchen-sink/schema.sql
@@ -29,7 +29,9 @@ create table another_thing (
 create table anything_goes (
   foo              int,
   bar              int,
-  interval         interval
+  interval         interval,
+  json             json,
+  jsonb            jsonb
 );
 
 create view non_mutation_view as
@@ -162,9 +164,9 @@ insert into another_thing (note, published, tags, thing_id) values
   ('world', true, '{"c", "d"}', null),
   ('foo', false, '{"a"}', 2);
 
-insert into anything_goes (foo, bar) values
-  (1, 2),
-  (2, 3),
-  (3, 4);
+insert into anything_goes (foo, bar, json, jsonb) values
+  (1, 2, '{"a":1,"b":2,"c":3}', '{"a":1,"b":2,"c":3}'),
+  (2, 3, null, null),
+  (3, 4, null, null);
 
 commit;

--- a/src/graphql/types.js
+++ b/src/graphql/types.js
@@ -129,9 +129,12 @@ export const IntervalType = createStringScalarType({
   description: 'Some time span',
 })
 
-export const JSONType = createStringScalarType({
+export const JSONType = new GraphQLScalarType({
   name: 'JSON',
   description: 'An object not queryable by GraphQL',
+  serialize: JSON.stringify,
+  parseValue: JSON.parse,
+  parseLiteral: ast => (ast.kind === Kind.STRING ? JSON.parse(ast.value) : null),
 })
 
 export const UUIDType = createStringScalarType({

--- a/tests/integration/fixtures/types.graphql
+++ b/tests/integration/fixtures/types.graphql
@@ -1,0 +1,11 @@
+query Types {
+  anythingGoesNodes(orderBy: FOO) {
+    nodes {
+      foo
+      bar
+      interval
+      json
+      jsonb
+    }
+  }
+}

--- a/tests/integration/fixtures/types.json
+++ b/tests/integration/fixtures/types.json
@@ -1,0 +1,29 @@
+{
+  "data": {
+    "anythingGoesNodes": {
+      "nodes": [
+        {
+          "foo": 1,
+          "bar": 2,
+          "interval": null,
+          "json": "{\"a\":1,\"b\":2,\"c\":3}",
+          "jsonb": "{\"a\":1,\"b\":2,\"c\":3}"
+        },
+        {
+          "foo": 2,
+          "bar": 3,
+          "interval": null,
+          "json": null,
+          "jsonb": null
+        },
+        {
+          "foo": 3,
+          "bar": 4,
+          "interval": null,
+          "json": null,
+          "jsonb": null
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
JSON objects have been serializing incorrectly. This has been mentioned a couple of times like in https://github.com/calebmer/postgraphql/issues/116 or https://github.com/calebmer/postgraphql/pull/102.

This fixes the problem, but still doesn’t add arbitrary JSON to the tree as is advocated in https://github.com/calebmer/postgraphql/pull/102 :+1: