### PR TITLE
Add schema watch functionality to CLI and middleware

### DIFF
--- a/docs/library.md
+++ b/docs/library.md
@@ -50,7 +50,7 @@ Arguments include:
   - `pgDefaultRole`: The default Postgres role to use. If no role was provided in a provided JWT token, this role will be used.
   - `jwtSecret`: The secret for your JSON web tokens. This will be used to verify tokens in the `Authorization` header, and signing JWT tokens you return in procedures.
   - `jwtPgTypeIdentifier`: The Postgres type identifier for the compound type which will be signed as a JWT token if ever found as the return type of a procedure. Can be of the form: `my_schema.my_type`. You may use quotes as needed: `"my-special-schema".my_type`.
-  - `watchPg`: PostGraphQL will watch your database schemas and re-create the GraphQL API when your schema changes.
+  - `watchPg`: When true, PostGraphQL will watch your database schemas and re-create the GraphQL API whenever your schema changes, notifying you as it does.
   - `disableQueryLog`: Turns off GraphQL query logging. By default PostGraphQL will log every GraphQL query it processes along with some other information. Set this to `true` to disable that feature.
   - `enableCors`: Enables some generous CORS settings for the GraphQL endpoint. There are some costs associated when enabling this, if at all possible try to put your API behind a reverse proxy.
 

--- a/docs/library.md
+++ b/docs/library.md
@@ -50,7 +50,7 @@ Arguments include:
   - `pgDefaultRole`: The default Postgres role to use. If no role was provided in a provided JWT token, this role will be used.
   - `jwtSecret`: The secret for your JSON web tokens. This will be used to verify tokens in the `Authorization` header, and signing JWT tokens you return in procedures.
   - `jwtPgTypeIdentifier`: The Postgres type identifier for the compound type which will be signed as a JWT token if ever found as the return type of a procedure. Can be of the form: `my_schema.my_type`. You may use quotes as needed: `"my-special-schema".my_type`.
-  - `watchPg`: When true, PostGraphQL will watch your database schemas and re-create the GraphQL API whenever your schema changes, notifying you as it does.
+  - `watchPg`: When true, PostGraphQL will watch your database schemas and re-create the GraphQL API whenever your schema changes, notifying you as it does. This feature requires an event trigger to be added to the database by a superuser. When enabled PostGraphQL will try to add this trigger, if you did not connect as a superuser you will get a warning and the trigger won’t be added.
   - `disableQueryLog`: Turns off GraphQL query logging. By default PostGraphQL will log every GraphQL query it processes along with some other information. Set this to `true` to disable that feature.
   - `enableCors`: Enables some generous CORS settings for the GraphQL endpoint. There are some costs associated when enabling this, if at all possible try to put your API behind a reverse proxy.
 

--- a/docs/library.md
+++ b/docs/library.md
@@ -50,6 +50,7 @@ Arguments include:
   - `pgDefaultRole`: The default Postgres role to use. If no role was provided in a provided JWT token, this role will be used.
   - `jwtSecret`: The secret for your JSON web tokens. This will be used to verify tokens in the `Authorization` header, and signing JWT tokens you return in procedures.
   - `jwtPgTypeIdentifier`: The Postgres type identifier for the compound type which will be signed as a JWT token if ever found as the return type of a procedure. Can be of the form: `my_schema.my_type`. You may use quotes as needed: `"my-special-schema".my_type`.
+  - `watchPg`: PostGraphQL will watch your database schemas and re-create the GraphQL API when your schema changes.
   - `disableQueryLog`: Turns off GraphQL query logging. By default PostGraphQL will log every GraphQL query it processes along with some other information. Set this to `true` to disable that feature.
   - `enableCors`: Enables some generous CORS settings for the GraphQL endpoint. There are some costs associated when enabling this, if at all possible try to put your API behind a reverse proxy.
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "testPathDirs": [
       "<rootDir>/src"
     ],
-    "testRegex": "/__tests__/[^.]+-test.(t|j)s$",
-    "clearMocks": true
+    "testRegex": "/__tests__/[^.]+-test.(t|j)s$"
   }
 }

--- a/resources/introspection-watch.sql
+++ b/resources/introspection-watch.sql
@@ -1,0 +1,61 @@
+-- Adds the functionality for PostGraphQL to watch the database for schema
+-- changes. This script is idempotent, you can run it as many times as you
+-- would like.
+
+begin;
+
+-- Drop the `postgraphql_watch` schema and all of its dependant objects
+-- including the event trigger function and the event trigger itself. We will
+-- recreate those objects in this script.
+drop schema postgraphql_watch cascade;
+
+-- Create a schema for the PostGraphQL watch functionality. This schema will
+-- hold things like trigger functions that are used to implement schema
+-- watching.
+create schema postgraphql_watch;
+
+-- This function will notify PostGraphQL of schema changes via a trigger.
+create function postgraphql_watch.notify_watchers() returns event_trigger as $$
+begin
+  perform pg_notify(
+    'postgraphql_watch',
+    (select array_to_json(array_agg(x)) from (select objid as id, command_tag as tag from pg_event_trigger_ddl_commands()) as x)::text
+  );
+end;
+$$ language plpgsql;
+
+-- Create an event trigger which will listen for the completion of all DDL
+-- events and report that they happened to PostGraphQL. Events are selected by
+-- whether or not they modify the static definition of `pg_catalog` that
+-- `introspection-query.sql` queries.
+create event trigger postgraphql_watch
+  on ddl_command_end
+  when tag in (
+    'ALTER DOMAIN',
+    'ALTER FOREIGN TABLE',
+    'ALTER FUNCTION',
+    'ALTER SCHEMA',
+    'ALTER TABLE',
+    'ALTER TYPE',
+    'ALTER VIEW',
+    'COMMENT',
+    'CREATE DOMAIN',
+    'CREATE FOREIGN TABLE',
+    'CREATE FUNCTION',
+    'CREATE SCHEMA',
+    'CREATE TABLE',
+    'CREATE TABLE AS',
+    'CREATE VIEW',
+    'DROP DOMAIN',
+    'DROP FOREIGN TABLE',
+    'DROP FUNCTION',
+    'DROP SCHEMA',
+    'DROP TABLE',
+    'DROP VIEW',
+    'GRANT',
+    'REVOKE',
+    'SELECT INTO'
+  )
+  execute procedure postgraphql_watch.notify_watchers();
+
+commit;

--- a/resources/watch-fixtures.sql
+++ b/resources/watch-fixtures.sql
@@ -7,7 +7,7 @@ begin;
 -- Drop the `postgraphql_watch` schema and all of its dependant objects
 -- including the event trigger function and the event trigger itself. We will
 -- recreate those objects in this script.
-drop schema postgraphql_watch cascade;
+drop schema if exists postgraphql_watch cascade;
 
 -- Create a schema for the PostGraphQL watch functionality. This schema will
 -- hold things like trigger functions that are used to implement schema

--- a/resources/watch-fixtures.sql
+++ b/resources/watch-fixtures.sql
@@ -19,7 +19,7 @@ create function postgraphql_watch.notify_watchers() returns event_trigger as $$
 begin
   perform pg_notify(
     'postgraphql_watch',
-    (select array_to_json(array_agg(x)) from (select objid as id, command_tag as tag from pg_event_trigger_ddl_commands()) as x)::text
+    (select array_to_json(array_agg(x)) from (select schema_name as schema, command_tag as command from pg_event_trigger_ddl_commands()) as x)::text
   );
 end;
 $$ language plpgsql;

--- a/scripts/dev
+++ b/scripts/dev
@@ -9,4 +9,4 @@ $npm_bin/nodemon \
   --ignore __tests__ \
   --ignore __mocks__ \
   --ext js,ts \
-  --exec "$npm_bin/ts-node --ignore node_modules --disableWarnings src/postgraphql/cli.ts --schema a,b,c --show-error-stack json $@"
+  --exec "$npm_bin/ts-node --ignore node_modules --disableWarnings src/postgraphql/cli.ts --schema a,b,c --show-error-stack json --watch $@"

--- a/src/postgraphql/cli.ts
+++ b/src/postgraphql/cli.ts
@@ -23,6 +23,7 @@ program
   // .option('-d, --demo', 'run PostGraphQL using the demo database connection')
   .option('-c, --connection <string>', 'the Postgres connection. if not provided it will be inferred from your environment')
   .option('-s, --schema <string>', 'a Postgres schema to be introspected. Use commas to define multiple schemas', (option: string) => option.split(','))
+  .option('-w, --watch', 'watches the Postgres schema for changes and reruns introspection if a change was detected')
   .option('-n, --host <string>', 'the hostname to be used. Defaults to `localhost`')
   .option('-p, --port <number>', 'the port to be used. Defaults to 5000', parseFloat)
   .option('-m, --max-pool-size <number>', 'the maximum number of clients to keep in the Postgres pool. defaults to 10', parseFloat)
@@ -54,6 +55,7 @@ process.on('SIGINT', process.exit)
 const {
   demo: isDemo = false,
   connection: pgConnectionString,
+  watch: watchPg,
   host: hostname = 'localhost',
   port = 5000,
   maxPoolSize,
@@ -102,9 +104,10 @@ const server = createServer(postgraphql(pgConfig, schemas, {
   jwtSecret,
   jwtPgTypeIdentifier,
   pgDefaultRole,
+  watchPg,
+  showErrorStack,
   disableQueryLog: false,
   enableCors,
-  showErrorStack,
 }))
 
 // Start our server by listening to a specific port and host name. Also log

--- a/src/postgraphql/http/createPostGraphQLHttpRequestHandler.d.ts
+++ b/src/postgraphql/http/createPostGraphQLHttpRequestHandler.d.ts
@@ -20,7 +20,7 @@ export interface HttpRequestHandler {
  */
 export default function createPostGraphQLHttpRequestHandler (config: {
   // The actual GraphQL schema we will use.
-  graphqlSchema: GraphQLSchema | Promise<GraphQLSchema>,
+  getGqlSchema: () => Promise<GraphQLSchema>,
 
   // A Postgres client pool we use to connect Postgres clients.
   pgPool: Pool,

--- a/src/postgraphql/postgraphql.ts
+++ b/src/postgraphql/postgraphql.ts
@@ -1,7 +1,10 @@
 import { Pool, PoolConfig } from 'pg'
 import { parse as parsePgConnectionString } from 'pg-connection-string'
+import { GraphQLSchema } from 'graphql'
+import chalk = require('chalk')
 import createPostGraphQLSchema from './schema/createPostGraphQLSchema'
 import createPostGraphQLHttpRequestHandler, { HttpRequestHandler } from './http/createPostGraphQLHttpRequestHandler'
+import watchPgSchemas from './watch/watchPgSchemas'
 
 /**
  * Creates a PostGraphQL Http request handler by first introspecting the
@@ -20,11 +23,15 @@ export default function postgraphql (
     pgDefaultRole?: string,
     jwtSecret?: string,
     jwtPgTypeIdentifier?: string,
+    watchPg?: boolean,
     showErrorStack?: boolean,
     disableQueryLog?: boolean,
     enableCors?: boolean,
   } = {},
 ): HttpRequestHandler {
+  // Creates the Postgres schemas array.
+  const pgSchemas: Array<string> = Array.isArray(schema) ? schema : [schema]
+
   // Do some things with `poolOrConfig` so that in the end, we actually get a
   // Postgres pool.
   const pgPool =
@@ -42,28 +49,69 @@ export default function postgraphql (
 
   // Creates a promise which will resolve to a GraphQL schema. Connects a
   // client from our pool to introspect the database.
-  const graphqlSchema = (async () => {
-    const pgClient = await pgPool.connect()
-    const subGraphqlSchema = await createPostGraphQLSchema(pgClient, schema, options)
+  //
+  // This is not a constant because when we are in watch mode, we want to swap
+  // out the `gqlSchema`.
+  let gqlSchema = createGqlSchema()
 
-    // If no release function exists, don’t release. This is just for tests.
-    if (pgClient && pgClient.release)
-      pgClient.release()
+  // If the user wants us to watch the schema, execute the following:
+  if (options.watchPg) {
+    watchPgSchemas({
+      pgPool,
+      pgSchemas,
+      onChange: ({ commands }) => {
+        // tslint:disable-next-line no-console
+        console.log(`Restarting PostGraphQL API after Postgres command(s)${options.graphiql ? '. Make sure to reload GraphiQL' : ''}: ️${commands.map(command => chalk.bold.cyan(command)).join(', ')}`)
 
-    return subGraphqlSchema
-  })()
-
-  // If we fail to build our schema, log the error and exit the process.
-  graphqlSchema.catch(error => {
-    // tslint:disable-next-line no-console
-    console.error(`${error.stack}\n`)
-    process.exit(1)
-  })
+        // Actually restart the GraphQL schema by creating a new one. Note that
+        // `createGqlSchema` returns a promise and we aren’t ‘await’ing it.
+        gqlSchema = createGqlSchema()
+      },
+    })
+      // If an error occurs when watching the Postgres schemas, log the error and
+      // exit the process.
+      .catch(error => {
+        // tslint:disable-next-line no-console
+        console.error(`${error.stack}\n`)
+        process.exit(1)
+      })
+  }
 
   // Finally create our Http request handler using our options, the Postgres
   // pool, and GraphQL schema. Return the final result.
   return createPostGraphQLHttpRequestHandler(Object.assign({}, options, {
-    graphqlSchema,
+    getGqlSchema: () => gqlSchema,
     pgPool,
   }))
+
+  /**
+   * Creates a GraphQL schema by connecting a client from our pool which will
+   * be used to introspect our Postgres database. If this function fails, we
+   * will log the error and exit the process.
+   *
+   * This may only be executed once, at startup. However, if we are in watch
+   * mode this will be updated whenever there is a change in our schema.
+   */
+  async function createGqlSchema (): Promise<GraphQLSchema> {
+    try {
+      const pgClient = await pgPool.connect()
+      const newGqlSchema = await createPostGraphQLSchema(pgClient, pgSchemas, options)
+
+      // If no release function exists, don’t release. This is just for tests.
+      if (pgClient && pgClient.release)
+        pgClient.release()
+
+      return newGqlSchema
+    }
+    // If we fail to build our schema, log the error and exit the process.
+    catch (error) {
+      // tslint:disable no-console
+      console.error(`${error.stack}\n`)
+      process.exit(1)
+
+      // This is just here to make TypeScript type check. `process.exit` will
+      // quit our program meaning we never execute this code.
+      return null as never
+    }
+  }
 }

--- a/src/postgraphql/watch/__tests__/watchPgSchemas-test.js
+++ b/src/postgraphql/watch/__tests__/watchPgSchemas-test.js
@@ -1,0 +1,69 @@
+jest.useFakeTimers()
+
+import watchPgSchemas, { _watchFixturesQuery } from '../watchPgSchemas'
+
+const chalk = require('chalk')
+
+test('will connect a client from the provided pool, run some SQL, and listen for notifications', async () => {
+  const pgClient = { query: jest.fn(() => Promise.resolve()), on: jest.fn() }
+  const pgPool = { connect: jest.fn(() => Promise.resolve(pgClient)) }
+  await watchPgSchemas({ pgPool })
+  expect(pgPool.connect.mock.calls).toEqual([[]])
+  expect(pgClient.query.mock.calls).toEqual([[await _watchFixturesQuery], ['listen postgraphql_watch']])
+  expect(pgClient.on.mock.calls.length).toBe(1)
+  expect(pgClient.on.mock.calls[0].length).toBe(2)
+  expect(pgClient.on.mock.calls[0][0]).toBe('notification')
+  expect(typeof pgClient.on.mock.calls[0][1]).toBe('function')
+})
+
+test('will log some stuff and continue if the watch fixtures query fails', async () => {
+  const pgClient = {
+    query: jest.fn(async query => {
+      if (query === await _watchFixturesQuery)
+        throw new Error('oops!')
+    }),
+    on: jest.fn(),
+  }
+  const pgPool = {
+    connect: jest.fn(() => Promise.resolve(pgClient)),
+  }
+  const mockWarn = jest.fn()
+  const origWarn = console.warn
+  console.warn = mockWarn
+  await watchPgSchemas({ pgPool })
+  console.warn = origWarn
+  expect(pgPool.connect.mock.calls).toEqual([[]])
+  expect(pgClient.query.mock.calls).toEqual([[await _watchFixturesQuery], ['listen postgraphql_watch']])
+  expect(pgClient.on.mock.calls.length).toBe(1)
+  expect(pgClient.on.mock.calls[0].length).toBe(2)
+  expect(pgClient.on.mock.calls[0][0]).toBe('notification')
+  expect(typeof pgClient.on.mock.calls[0][1]).toBe('function')
+  expect(mockWarn.mock.calls).toEqual([
+    [chalk.bold.yellow('Failed to setup watch fixtures in Postgres database') + ' ️️⚠️'],
+    [chalk.yellow('This is likely because your Postgres user is not a superuser. If the')],
+    [chalk.yellow('fixtures already exist, the watch functionality may still work.')],
+  ])
+})
+
+test('will call `onChange` with the appropriate commands from the notification listener', async () => {
+  const onChange = jest.fn()
+  let notificationListener
+  const pgClient = { query: jest.fn(), on: jest.fn((event, listener) => notificationListener = listener) }
+  const pgPool = { connect: jest.fn(() => pgClient) }
+  await watchPgSchemas({ pgPool, pgSchemas: ['a', 'b'], onChange })
+  const notifications = [
+    {},
+    { payload: '' },
+    { channel: 'postgraphql_watch' },
+    { channel: 'unknown_channel', payload: 'error!' },
+    { channel: 'postgraphql_watch', payload: '' },
+    { channel: 'postgraphql_watch', payload: JSON.stringify([{ schema: 'a', command: '1' }]) },
+    { channel: 'postgraphql_watch', payload: JSON.stringify([{ schema: 'b', command: '2' }]) },
+    { channel: 'postgraphql_watch', payload: JSON.stringify([{ schema: 'a', command: '3' }, { schema: 'b', command: '4' }]) },
+    { channel: 'postgraphql_watch', payload: JSON.stringify([{ schema: 'c', command: '5' }]) },
+    { channel: 'postgraphql_watch', payload: JSON.stringify([{ schema: 'a', command: '6' }, { schema: 'c', command: '7' }, { schema: 'b', command: '8' }]) },
+  ]
+  notifications.forEach(notification => notificationListener(notification))
+  jest.runAllTimers()
+  expect(onChange.mock.calls).toEqual([[{ commands: ['1', '2', '3', '4', '6', '8'] }]])
+})

--- a/src/postgraphql/watch/watchPgSchemas.ts
+++ b/src/postgraphql/watch/watchPgSchemas.ts
@@ -1,0 +1,104 @@
+import { resolve as resolvePath } from 'path'
+import { readFile } from 'fs'
+import chalk = require('chalk')
+import { Pool } from 'pg'
+import minify = require('pg-minify')
+
+/**
+ * This query creates some fixtures required to watch a Postgres database.
+ * Most notably an event trigger.
+ */
+export const _watchFixturesQuery = new Promise<string>((resolve, reject) => {
+  readFile(resolvePath(__dirname, '../../../resources/watch-fixtures.sql'), (error, data) => {
+    if (error) reject(error)
+    else resolve(minify(data.toString()))
+  })
+})
+
+/**
+ * Watches a Postgres schema for changes. Does this by running a query which
+ * sets up some fixtures for watching the database including, most importantly,
+ * a DDL event trigger (if the script can’t be applied it isn’t fatal, just a
+ * warning).
+ *
+ * The event trigger will then notify PostGraphQL whenever DDL queries are
+ * succesfully run. PostGraphQL will emit these notifications to a provided
+ * `onChange` handler.
+ */
+export default async function watchPgSchemas ({ pgPool, pgSchemas, onChange }: {
+  pgPool: Pool,
+  pgSchemas: Array<string>,
+  onChange: (info: { commands: Array<string> }) => void,
+}): Promise<void> {
+  // Connect a client from our pool. Note that we never release this query
+  // back to the pool. We keep it forever to receive notifications.
+  const pgClient = await pgPool.connect()
+
+  // Try to apply our watch fixtures to the database. If the query fails, fail
+  // gracefully with a warning as the feature may still work.
+  try {
+    await pgClient.query(await _watchFixturesQuery)
+  }
+  catch (error) {
+    // tslint:disable no-console
+    console.warn(`${chalk.bold.yellow('Failed to setup watch fixtures in Postgres database')} ️️⚠️`)
+    console.warn(chalk.yellow('This is likely because your Postgres user is not a superuser. If the'))
+    console.warn(chalk.yellow('fixtures already exist, the watch functionality may still work.'))
+    // tslint:enable no-console
+  }
+
+  // Listen to the `postgraphql_watch` channel. Any and all updates will come
+  // through here.
+  await pgClient.query('listen postgraphql_watch')
+
+  // Flushes our `commandsQueue` to the `onChange` listener. This function is
+  // debounced, so it may not flush synchronously. It will accumulate commands
+  // and send them in batches all at once.
+  const flushCommands = (() => {
+    // tslint:disable-next-line no-any
+    let lastTimeoutId: any = null
+    let commandsBuffer: Array<string> = []
+
+    return (commands: Array<string>) => {
+      // Add all of our commands to our internal buffer.
+      commandsBuffer = commandsBuffer.concat(commands)
+
+      // Clear the last timeout and start a new timer. This is effectively our
+      // ‘debounce’ implementation.
+      clearTimeout(lastTimeoutId)
+      lastTimeoutId = setTimeout(() => {
+        // Run the `onChange` listener with our commands buffer and clear
+        // our buffer.
+        onChange({ commands: commandsBuffer })
+        commandsBuffer = []
+      }, 500)
+    }
+  })()
+
+  // Process any notifications we may get.
+  pgClient.on('notification', notification => {
+    // If the notification is for the wrong channel or if the notification
+    // payload is falsy (when it’s an empty string), don’t process this
+    // notification.
+    if (notification.channel !== 'postgraphql_watch' || !notification.payload)
+      return
+
+    // Parse our payload into a JSON object and give it some type information.
+    const payload: Array<{ schema: string | null, command: string }> = JSON.parse(notification.payload)
+
+    // Take our payload and filter out all of the ‘noise,’ i.e. the commands
+    // aren’t in the schemas we are watching. Then map to a format we can
+    // share.
+    const commands: Array<string> =
+      payload
+        .filter(({ schema }) => schema == null || pgSchemas.indexOf(schema) !== -1)
+        .map(({ command }) => command)
+
+    // If we filtered everything away, let’s return ang ignore those commands.
+    if (commands.length === 0)
+      return
+
+    // Finally flush our commands. This will happen asynchronously.
+    flushCommands(commands)
+  })
+}

--- a/src/postgres/introspection/introspectDatabase.ts
+++ b/src/postgres/introspection/introspectDatabase.ts
@@ -1,25 +1,25 @@
-import * as path from 'path'
+import { resolve as resolvePath } from 'path'
 import { readFile } from 'fs'
 import { Client } from 'pg'
 import minify = require('pg-minify')
 import PgCatalog from './PgCatalog'
 
 /**
- * The introspection query Sql string. We read this from it’s Sql file
+ * The introspection query SQL string. We read this from it’s SQL file
  * synchronously at runtime. It’s just like requiring a file, except that file
- * is Sql.
+ * is SQL.
  */
 const introspectionQuery = new Promise<string>((resolve, reject) => {
-  readFile(path.resolve(__dirname, '../../../resources/introspection-query.sql'), (error, data) => {
+  readFile(resolvePath(__dirname, '../../../resources/introspection-query.sql'), (error, data) => {
     if (error) reject(error)
     else resolve(minify(data.toString()))
   })
 })
 
 /**
- * Takes a PostgreSql client and introspects it, returning an instance of
+ * Takes a Postgres client and introspects it, returning an instance of
  * `PgObjects` which can then be consumed. Note that some translation is done
- * from the raw PostgreSql catalog to the friendlier `PgObjects` interface.
+ * from the raw Postgres catalog to the friendlier `PgObjects` interface.
  */
 export default async function introspectDatabase (client: Client, schemas: string[]): Promise<PgCatalog> {
   // Run our single introspection query in the database.


### PR DESCRIPTION
This PR adds watch functionality to PostGraphQL :tada:

When giving demonstrations of PostGraphQL I’d like to have a fast feedback cycle. Being able to have PostGraphQL open and watching in one window and a Postgres query input in the other while PostGraphQL automatically updates is a great way to get to a fast feedback cycle. I was going to just write a script, but instead I decided to just put it in the project :blush:

To use just pass in `--watch` and/or `watchPg: true` (depending on if you are using the CLI or the middleware). PostGraphQL will add an event trigger to your database (can only be done if you start PostGraphQL as a superuser), and whenever it gets a notification from that trigger PostGraphQL will automatically rebuild the schema. The next step is just to get GraphiQL to refresh it’s introspection automatically. See a demonstration below:

![PostGraphQL Watch Demonstration](https://cloud.githubusercontent.com/assets/8282507/19449685/9688d4f2-9474-11e6-9ad0-c00622f9efd4.gif)

Please review! I don’t want to merge without getting some eyeballs on the changes :wink:. The 2.0 PR was an exception.