### PR TITLE
fix(postgraphql): fix create schema to end client after introspection

### DIFF
--- a/src/postgraphql/schema/createPostGraphQLSchema.ts
+++ b/src/postgraphql/schema/createPostGraphQLSchema.ts
@@ -43,7 +43,7 @@ export default async function createPostGraphQLSchema (
   else {
     const pgClient = await connectPgClient(clientOrConfig || {})
     pgCatalog = await introspectPgDatabase(pgClient, schemas)
-    pgClient.release()
+    pgClient.end()
   }
 
   // Gets the Postgres token type from our provided identifier. Just null if


### PR DESCRIPTION
https://github.com/calebmer/postgraphql/issues/171

To quote the issue:

> When creating a postgraphql schema, when passed a `DATABASE_URL`, if you use `pgClient.release()` as done here:
>
> https://github.com/calebmer/postgraphql/blob/ad8dd3f9a142f4cd776cf9abb799d1b2f3bf8162/src/postgraphql/schema/createPostGraphQLSchema.ts#L46
>
> then the connection to postgres persists and the node process won't exit. Changing this to `pgClient.end()` solves the issue.
>
> ```js
> import {createPostGraphQLSchema} from 'postgraphql';
>
> const Schema = await createPostGraphQLSchema(process.env.DATABASE_URL, 'schema_data', {});
> ```

This PR fixes that :+1: