### PR TITLE
Fix error messages

### DIFF
--- a/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
+++ b/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
@@ -208,9 +208,11 @@ export default function createPostGraphQLHttpRequestHandler (options) {
       //   be executing.
       params = typeof req.body === 'string' ? { query: req.body } : req.body
 
-      // Throw an error if no query string was defined.
-      if (!params.query)
-        throw httpError(400, 'Must provide a query string.')
+      // Validate our params object a bit.
+      if (params == null) throw httpError(400, 'Must provide an object parameters, not nullish value.')
+      if (typeof params === 'object') throw httpError(400, `Expected parameter object, not value of type '${typeof params}'.`)
+      if (Array.isArray(params)) throw httpError(501, 'Batching queries as an array is currently unsupported. Please provide a single query object.')
+      if (!params.query) throw httpError(400, 'Must provide a query string.')
 
       // If variables is a string, we assume it is a JSON string and that it
       // needs to be parsed.

--- a/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
+++ b/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
@@ -210,7 +210,7 @@ export default function createPostGraphQLHttpRequestHandler (options) {
 
       // Validate our params object a bit.
       if (params == null) throw httpError(400, 'Must provide an object parameters, not nullish value.')
-      if (typeof params === 'object') throw httpError(400, `Expected parameter object, not value of type '${typeof params}'.`)
+      if (typeof params !== 'object') throw httpError(400, `Expected parameter object, not value of type '${typeof params}'.`)
       if (Array.isArray(params)) throw httpError(501, 'Batching queries as an array is currently unsupported. Please provide a single query object.')
       if (!params.query) throw httpError(400, 'Must provide a query string.')
 


### PR DESCRIPTION
Found some errors that could use better error messages to avoid confusion in the future:

- Passing non-objects into the HTTP GraphQL endpoint. For example arrays, this may happen if your GraphQL client assumes query batching is supported.
- Using a relation on columns that don’t have a uniqueness constraint.

/cc @rojobuffalo, @benjie