### PR TITLE
Add an option to disable default mutations. Closes #170

### DIFF
--- a/docs/library.md
+++ b/docs/library.md
@@ -44,6 +44,7 @@ Arguments include:
 - **`options`**: An object containing other miscellaneous options. Options could be:
   - `classicIds`: Enables classic ids for Relay 1 support. Instead of using the field name `__id` for globally unique ids, PostGraphQL will instead use the field name `id` for its globally unique ids. This means that table `id` columns will also get renamed to `rowId`.
   - `dynamicJson`: Setting this to `true` enables dynamic JSON which will allow you to use any JSON as input and get any arbitrary JSON as output. By default JSON types are just a JSON string.
+  - `disableDefaultMutations`: Setting this to `true` will prevent the creation of the default mutation types & fields. Database mutation will only be possible through Postgres functions.
   - `graphiql`: Set this to `true` to enable the GraphiQL interface.
   - `graphqlRoute`: The endpoint the GraphQL executer will listen on. Defaults to `/graphql`.
   - `graphiqlRoute`: The endpoint the GraphiQL query interface will listen on (**NOTE:** GraphiQL will not be enabled unless the `graphiql` option is set to `true`). Defaults to `/graphiql`.

--- a/src/graphql/schema/BuildToken.ts
+++ b/src/graphql/schema/BuildToken.ts
@@ -27,6 +27,9 @@ interface BuildToken {
     // By default, JSON is output as a string in our GraphQL queries. If true
     // then JSON will be output as a dynamic object.
     readonly dynamicJson: boolean,
+    // If true then the default mutations for tables (e.g. createMyTable) will
+    // not be created
+    readonly disableDefaultMutations: boolean,
   },
   // Hooks for adding custom fields/types into our schema.
   readonly _hooks: _BuildTokenHooks,

--- a/src/graphql/schema/createGqlSchema.ts
+++ b/src/graphql/schema/createGqlSchema.ts
@@ -36,6 +36,7 @@ export default function createGqlSchema (inventory: Inventory, options: SchemaOp
     options: {
       nodeIdFieldName: options.nodeIdFieldName || '__id',
       dynamicJson: options.dynamicJson || false,
+      disableDefaultMutations: options.disableDefaultMutations || false,
     },
     _hooks: options._hooks || {},
     _typeOverrides: options._typeOverrides || new Map(),
@@ -43,6 +44,6 @@ export default function createGqlSchema (inventory: Inventory, options: SchemaOp
 
   return new GraphQLSchema({
     query: getQueryGqlType(buildToken),
-    mutation: getMutationGqlType(buildToken, options),
+    mutation: getMutationGqlType(buildToken),
   })
 }

--- a/src/graphql/schema/createGqlSchema.ts
+++ b/src/graphql/schema/createGqlSchema.ts
@@ -12,6 +12,9 @@ export type SchemaOptions = {
   // If true then any literal will be accepted to this type and its output will
   // be plain JSON.
   dynamicJson?: boolean,
+  // If true then the default mutations for tables (e.g. createMyTable) will
+  // not be created
+  disableDefaultMutations?: boolean,
   // Some hooks to allow extension of the schema. Currently this API is
   // private. Use at your own risk.
   _hooks?: _BuildTokenHooks,
@@ -40,6 +43,6 @@ export default function createGqlSchema (inventory: Inventory, options: SchemaOp
 
   return new GraphQLSchema({
     query: getQueryGqlType(buildToken),
-    mutation: getMutationGqlType(buildToken),
+    mutation: getMutationGqlType(buildToken, options.disableDefaultMutations),
   })
 }

--- a/src/graphql/schema/createGqlSchema.ts
+++ b/src/graphql/schema/createGqlSchema.ts
@@ -43,6 +43,6 @@ export default function createGqlSchema (inventory: Inventory, options: SchemaOp
 
   return new GraphQLSchema({
     query: getQueryGqlType(buildToken),
-    mutation: getMutationGqlType(buildToken, options.disableDefaultMutations),
+    mutation: getMutationGqlType(buildToken, options),
   })
 }

--- a/src/graphql/schema/getMutationGqlType.ts
+++ b/src/graphql/schema/getMutationGqlType.ts
@@ -1,5 +1,5 @@
 import { GraphQLObjectType, GraphQLFieldConfig } from 'graphql'
-import { buildObject, memoize2 } from '../utils'
+import { buildObject, memoize1 } from '../utils'
 import BuildToken from './BuildToken'
 import createCollectionMutationFieldEntries from './collection/createCollectionMutationFieldEntries'
 
@@ -8,7 +8,7 @@ import createCollectionMutationFieldEntries from './collection/createCollectionM
  * schema. If there are no mutations, instead of throwing an error we will just
  * return `undefined`.
  */
-const getMutationGqlType = memoize2(createMutationGqlType)
+const getMutationGqlType = memoize1(createMutationGqlType)
 
 export default getMutationGqlType
 
@@ -17,8 +17,8 @@ export default getMutationGqlType
  *
  * @private
  */
-function createMutationGqlType (buildToken: BuildToken, options: { disableDefaultMutations?: boolean } = {}): GraphQLObjectType<mixed> | undefined {
-  const { inventory } = buildToken
+function createMutationGqlType (buildToken: BuildToken): GraphQLObjectType<mixed> | undefined {
+  const { inventory, options } = buildToken
 
   // A list of all the mutations we are able to run.
   const mutationFieldEntries: Array<[string, GraphQLFieldConfig<mixed, mixed>]> = [

--- a/src/graphql/schema/getMutationGqlType.ts
+++ b/src/graphql/schema/getMutationGqlType.ts
@@ -1,5 +1,5 @@
 import { GraphQLObjectType, GraphQLFieldConfig } from 'graphql'
-import { buildObject, memoize1 } from '../utils'
+import { buildObject, memoize2 } from '../utils'
 import BuildToken from './BuildToken'
 import createCollectionMutationFieldEntries from './collection/createCollectionMutationFieldEntries'
 
@@ -8,7 +8,7 @@ import createCollectionMutationFieldEntries from './collection/createCollectionM
  * schema. If there are no mutations, instead of throwing an error we will just
  * return `undefined`.
  */
-const getMutationGqlType = memoize1(createMutationGqlType)
+const getMutationGqlType = memoize2(createMutationGqlType)
 
 export default getMutationGqlType
 
@@ -17,7 +17,7 @@ export default getMutationGqlType
  *
  * @private
  */
-function createMutationGqlType (buildToken: BuildToken): GraphQLObjectType<mixed> | undefined {
+function createMutationGqlType (buildToken: BuildToken, disableDefaultMutations?: boolean): GraphQLObjectType<mixed> | undefined {
   const { inventory } = buildToken
 
   // A list of all the mutations we are able to run.
@@ -29,12 +29,14 @@ function createMutationGqlType (buildToken: BuildToken): GraphQLObjectType<mixed
         : []
     ),
     ...(
-      // Get the mutations for all of our collections and creates mutations
-      // for them.
-      inventory
-        .getCollections()
-        .map(collection => createCollectionMutationFieldEntries(buildToken, collection))
-        .reduce((a, b) => a.concat(b), [])
+      disableDefaultMutations
+        ? []
+        : // Get the mutations for all of our collections and creates mutations
+          // for them.
+          inventory
+            .getCollections()
+            .map(collection => createCollectionMutationFieldEntries(buildToken, collection))
+            .reduce((a, b) => a.concat(b), [])
     ),
   ]
 

--- a/src/graphql/schema/getMutationGqlType.ts
+++ b/src/graphql/schema/getMutationGqlType.ts
@@ -17,7 +17,7 @@ export default getMutationGqlType
  *
  * @private
  */
-function createMutationGqlType (buildToken: BuildToken, disableDefaultMutations?: boolean): GraphQLObjectType<mixed> | undefined {
+function createMutationGqlType (buildToken: BuildToken, options: { disableDefaultMutations?: boolean } = {}): GraphQLObjectType<mixed> | undefined {
   const { inventory } = buildToken
 
   // A list of all the mutations we are able to run.
@@ -29,7 +29,7 @@ function createMutationGqlType (buildToken: BuildToken, disableDefaultMutations?
         : []
     ),
     ...(
-      disableDefaultMutations
+      options.disableDefaultMutations
         ? []
         : // Get the mutations for all of our collections and creates mutations
           // for them.

--- a/src/postgraphql/__tests__/__snapshots__/postgraphqlIntegrationOperations-test.js.snap
+++ b/src/postgraphql/__tests__/__snapshots__/postgraphqlIntegrationOperations-test.js.snap
@@ -507,6 +507,489 @@ Object {
 exports[`test operation dynamic-json.graphql 1`] = `
 Object {
   "data": Object {
+    "a": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+          "node": Object {
+            "email": "john.smith@email.com",
+            "id": 1,
+            "name": "John Smith",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsyXV0=",
+          "node": Object {
+            "email": "sara.smith@email.com",
+            "id": 2,
+            "name": "Sara Smith",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
+          "node": Object {
+            "email": "budd.deey@email.com",
+            "id": 3,
+            "name": "Budd Deey",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs0XV0=",
+          "node": Object {
+            "email": "kathryn.ramirez@email.com",
+            "id": 4,
+            "name": "Kathryn Ramirez",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
+          "node": Object {
+            "email": "joe.tucker@email.com",
+            "id": 5,
+            "name": "Joe Tucker",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
+        "hasNextPage": false,
+        "hasPreviousPage": false,
+        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+      },
+      "totalCount": 5,
+    },
+    "b": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+          "node": Object {
+            "email": "john.smith@email.com",
+            "id": 1,
+            "name": "John Smith",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsyXV0=",
+          "node": Object {
+            "email": "sara.smith@email.com",
+            "id": 2,
+            "name": "Sara Smith",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsyXV0=",
+        "hasNextPage": true,
+        "hasPreviousPage": false,
+        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+      },
+      "totalCount": 5,
+    },
+    "c": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs0XV0=",
+          "node": Object {
+            "email": "kathryn.ramirez@email.com",
+            "id": 4,
+            "name": "Kathryn Ramirez",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
+          "node": Object {
+            "email": "joe.tucker@email.com",
+            "id": 5,
+            "name": "Joe Tucker",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
+        "hasNextPage": false,
+        "hasPreviousPage": true,
+        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs0XV0=",
+      },
+      "totalCount": 5,
+    },
+    "d": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJuYW1lX2FzYyIsWyJCdWRkIERlZXkiLDNdXQ==",
+          "node": Object {
+            "email": "budd.deey@email.com",
+            "id": 3,
+            "name": "Budd Deey",
+          },
+        },
+        Object {
+          "cursor": "WyJuYW1lX2FzYyIsWyJKb2UgVHVja2VyIiw1XV0=",
+          "node": Object {
+            "email": "joe.tucker@email.com",
+            "id": 5,
+            "name": "Joe Tucker",
+          },
+        },
+        Object {
+          "cursor": "WyJuYW1lX2FzYyIsWyJKb2huIFNtaXRoIiwxXV0=",
+          "node": Object {
+            "email": "john.smith@email.com",
+            "id": 1,
+            "name": "John Smith",
+          },
+        },
+        Object {
+          "cursor": "WyJuYW1lX2FzYyIsWyJLYXRocnluIFJhbWlyZXoiLDRdXQ==",
+          "node": Object {
+            "email": "kathryn.ramirez@email.com",
+            "id": 4,
+            "name": "Kathryn Ramirez",
+          },
+        },
+        Object {
+          "cursor": "WyJuYW1lX2FzYyIsWyJTYXJhIFNtaXRoIiwyXV0=",
+          "node": Object {
+            "email": "sara.smith@email.com",
+            "id": 2,
+            "name": "Sara Smith",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJuYW1lX2FzYyIsWyJTYXJhIFNtaXRoIiwyXV0=",
+        "hasNextPage": false,
+        "hasPreviousPage": false,
+        "startCursor": "WyJuYW1lX2FzYyIsWyJCdWRkIERlZXkiLDNdXQ==",
+      },
+      "totalCount": 5,
+    },
+    "e": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJuYW1lX2Rlc2MiLFsiU2FyYSBTbWl0aCIsMl1d",
+          "node": Object {
+            "email": "sara.smith@email.com",
+            "id": 2,
+            "name": "Sara Smith",
+          },
+        },
+        Object {
+          "cursor": "WyJuYW1lX2Rlc2MiLFsiS2F0aHJ5biBSYW1pcmV6Iiw0XV0=",
+          "node": Object {
+            "email": "kathryn.ramirez@email.com",
+            "id": 4,
+            "name": "Kathryn Ramirez",
+          },
+        },
+        Object {
+          "cursor": "WyJuYW1lX2Rlc2MiLFsiSm9obiBTbWl0aCIsMV1d",
+          "node": Object {
+            "email": "john.smith@email.com",
+            "id": 1,
+            "name": "John Smith",
+          },
+        },
+        Object {
+          "cursor": "WyJuYW1lX2Rlc2MiLFsiSm9lIFR1Y2tlciIsNV1d",
+          "node": Object {
+            "email": "joe.tucker@email.com",
+            "id": 5,
+            "name": "Joe Tucker",
+          },
+        },
+        Object {
+          "cursor": "WyJuYW1lX2Rlc2MiLFsiQnVkZCBEZWV5IiwzXV0=",
+          "node": Object {
+            "email": "budd.deey@email.com",
+            "id": 3,
+            "name": "Budd Deey",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJuYW1lX2Rlc2MiLFsiQnVkZCBEZWV5IiwzXV0=",
+        "hasNextPage": false,
+        "hasPreviousPage": false,
+        "startCursor": "WyJuYW1lX2Rlc2MiLFsiU2FyYSBTbWl0aCIsMl1d",
+      },
+      "totalCount": 5,
+    },
+    "f": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+          "node": Object {
+            "email": "john.smith@email.com",
+            "id": 1,
+            "name": "John Smith",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+        "hasNextPage": true,
+        "hasPreviousPage": false,
+        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+      },
+      "totalCount": 5,
+    },
+    "g": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
+          "node": Object {
+            "email": "budd.deey@email.com",
+            "id": 3,
+            "name": "Budd Deey",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs0XV0=",
+          "node": Object {
+            "email": "kathryn.ramirez@email.com",
+            "id": 4,
+            "name": "Kathryn Ramirez",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
+          "node": Object {
+            "email": "joe.tucker@email.com",
+            "id": 5,
+            "name": "Joe Tucker",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs1XV0=",
+        "hasNextPage": false,
+        "hasPreviousPage": true,
+        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
+      },
+      "totalCount": 5,
+    },
+    "h": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJuYXR1cmFsIiwxXQ==",
+          "node": Object {
+            "constant": 2,
+            "name": "John Smith",
+            "x": 1,
+          },
+        },
+        Object {
+          "cursor": "WyJuYXR1cmFsIiwyXQ==",
+          "node": Object {
+            "constant": 2,
+            "name": "Sara Smith",
+            "x": 2,
+          },
+        },
+        Object {
+          "cursor": "WyJuYXR1cmFsIiwzXQ==",
+          "node": Object {
+            "constant": 2,
+            "name": "Budd Deey",
+            "x": 3,
+          },
+        },
+        Object {
+          "cursor": "WyJuYXR1cmFsIiw0XQ==",
+          "node": Object {
+            "constant": 2,
+            "name": "Kathryn Ramirez",
+            "x": 4,
+          },
+        },
+        Object {
+          "cursor": "WyJuYXR1cmFsIiw1XQ==",
+          "node": Object {
+            "constant": 2,
+            "name": "Joe Tucker",
+            "x": 5,
+          },
+        },
+      ],
+    },
+    "i": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJjb25zdGFudF9hc2MiLFsyXV0=",
+          "node": Object {
+            "constant": 2,
+            "name": "John Smith",
+            "x": 1,
+          },
+        },
+        Object {
+          "cursor": "WyJjb25zdGFudF9hc2MiLFsyXV0=",
+          "node": Object {
+            "constant": 2,
+            "name": "Sara Smith",
+            "x": 2,
+          },
+        },
+        Object {
+          "cursor": "WyJjb25zdGFudF9hc2MiLFsyXV0=",
+          "node": Object {
+            "constant": 2,
+            "name": "Budd Deey",
+            "x": 3,
+          },
+        },
+        Object {
+          "cursor": "WyJjb25zdGFudF9hc2MiLFsyXV0=",
+          "node": Object {
+            "constant": 2,
+            "name": "Kathryn Ramirez",
+            "x": 4,
+          },
+        },
+        Object {
+          "cursor": "WyJjb25zdGFudF9hc2MiLFsyXV0=",
+          "node": Object {
+            "constant": 2,
+            "name": "Joe Tucker",
+            "x": 5,
+          },
+        },
+      ],
+    },
+    "j": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+          "node": Object {
+            "authorId": 2,
+            "headline": "No… It’s a thing; it’s like a plan, but with more greatness.",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs4XV0=",
+          "node": Object {
+            "authorId": 2,
+            "headline": "It’s a fez. I wear a fez now. Fezes are cool.",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxMF1d",
+          "node": Object {
+            "authorId": 2,
+            "headline": "What’s with you kids? Every other day it’s food, food, food.",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxMF1d",
+        "hasNextPage": false,
+        "hasPreviousPage": false,
+        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+      },
+      "totalCount": 3,
+    },
+    "k": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+          "node": Object {
+            "authorId": 2,
+            "headline": "No… It’s a thing; it’s like a plan, but with more greatness.",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs4XV0=",
+          "node": Object {
+            "authorId": 2,
+            "headline": "It’s a fez. I wear a fez now. Fezes are cool.",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs4XV0=",
+        "hasNextPage": true,
+        "hasPreviousPage": false,
+        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsxXV0=",
+      },
+      "totalCount": 3,
+    },
+    "l": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJoZWFkbGluZV9hc2MiLFsiWW91IGhpdCBtZSB3aXRoIGEgY3JpY2tldCBiYXQuIiw0XV0=",
+          "node": Object {
+            "authorId": 1,
+            "headline": "You hit me with a cricket bat.",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJoZWFkbGluZV9hc2MiLFsiWW91IGhpdCBtZSB3aXRoIGEgY3JpY2tldCBiYXQuIiw0XV0=",
+        "hasNextPage": false,
+        "hasPreviousPage": true,
+        "startCursor": "WyJoZWFkbGluZV9hc2MiLFsiWW91IGhpdCBtZSB3aXRoIGEgY3JpY2tldCBiYXQuIiw0XV0=",
+      },
+      "totalCount": 4,
+    },
+    "m": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsyXV0=",
+          "node": Object {
+            "email": "sara.smith@email.com",
+            "id": 2,
+            "name": "Sara Smith",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFszXV0=",
+          "node": Object {
+            "email": "budd.deey@email.com",
+            "id": 3,
+            "name": "Budd Deey",
+          },
+        },
+        Object {
+          "cursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs0XV0=",
+          "node": Object {
+            "email": "kathryn.ramirez@email.com",
+            "id": 4,
+            "name": "Kathryn Ramirez",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "endCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFs0XV0=",
+        "hasNextPage": true,
+        "hasPreviousPage": true,
+        "startCursor": "WyJwcmltYXJ5X2tleV9hc2MiLFsyXV0=",
+      },
+      "totalCount": 5,
+    },
+    "n": Object {
+      "edges": Array [],
+      "pageInfo": Object {
+        "endCursor": null,
+        "hasNextPage": false,
+        "hasPreviousPage": false,
+        "startCursor": null,
+      },
+      "totalCount": 5,
+    },
+    "o": Object {
+      "nodes": Array [
+        Object {
+          "rowId": 2,
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`test operation mutation-create.graphql 1`] = `
+Object {
+  "data": Object {
     "a": true,
     "allTypes": Object {
       "nodes": Array [
@@ -599,7 +1082,7 @@ Object {
 }
 `;
 
-exports[`test operation mutation-create.graphql 1`] = `
+exports[`test operation mutation-create.graphql 2`] = `
 Object {
   "data": Object {
     "a": Object {

--- a/src/postgraphql/__tests__/__snapshots__/postgraphqlIntegrationSchema-test.js.snap
+++ b/src/postgraphql/__tests__/__snapshots__/postgraphqlIntegrationSchema-test.js.snap
@@ -1,4 +1,2593 @@
 exports[`test prints a schema with Relay 1 style ids 1`] = `
+"# All input for the \`add1Mutation\` mutation.
+input Add1MutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  arg0: Int!
+  arg1: Int!
+}
+
+# The output of our \`add1Mutation\` mutation.
+type Add1MutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`add2Mutation\` mutation.
+input Add2MutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  a: Int!
+  b: Int!
+}
+
+# The output of our \`add2Mutation\` mutation.
+type Add2MutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`add3Mutation\` mutation.
+input Add3MutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  a: Int
+  arg1: Int
+}
+
+# The output of our \`add3Mutation\` mutation.
+type Add3MutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`add4Mutation\` mutation.
+input Add4MutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  arg0: Int
+  b: Int
+}
+
+# The output of our \`add4Mutation\` mutation.
+type Add4MutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+scalar AnInt
+
+type AnIntRange {
+  # The starting bound of our range.
+  start: AnIntRangeBound
+
+  # The ending bound of our range.
+  end: AnIntRangeBound
+}
+
+# The value at one end of a range. A range can either include this value, or not.
+type AnIntRangeBound {
+  # The value at one end of our range.
+  value: AnInt!
+
+  # Whether or not the value of this bound is included in the range.
+  inclusive: Boolean!
+}
+
+# The value at one end of a range. A range can either include this value, or not.
+input AnIntRangeBoundInput {
+  # The value at one end of our range.
+  value: AnInt!
+
+  # Whether or not the value of this bound is included in the range.
+  inclusive: Boolean!
+}
+
+input AnIntRangeInput {
+  # The starting bound of our range.
+  start: AnIntRangeBoundInput
+
+  # The ending bound of our range.
+  end: AnIntRangeBoundInput
+}
+
+scalar AnotherInt
+
+# All input for the \`authenticate\` mutation.
+input AuthenticateInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  a: Int
+  b: Int
+  c: Int
+}
+
+# All input for the \`authenticateMany\` mutation.
+input AuthenticateManyInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  a: Int
+  b: Int
+  c: Int
+}
+
+# The output of our \`authenticateMany\` mutation.
+type AuthenticateManyPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  jwtTokens: [JwtToken]
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# The output of our \`authenticate\` mutation.
+type AuthenticatePayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  jwtToken: JwtToken
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+enum Color {
+  RED
+  GREEN
+  BLUE
+}
+
+type CompoundKey implements Node {
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  __id: ID!
+  personId2: Int!
+  personId1: Int!
+  extra: Boolean
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId1: Person
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId2: Person
+
+  # Reads and enables paginatation through a set of \`ForeignKey\`.
+  foreignKeysByCompoundKey1AndCompoundKey2(
+    # The method to use when ordering \`ForeignKey\`.
+    orderBy: ForeignKeysOrderBy = NATURAL
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+  ): ForeignKeysConnection
+}
+
+# A condition to be used against \`CompoundKey\` object types. All fields are tested
+# for equality and combined with a logical ‘and.’
+input CompoundKeyCondition {
+  # Checks for equality with the object’s \`personId2\` field.
+  personId2: Int
+
+  # Checks for equality with the object’s \`personId1\` field.
+  personId1: Int
+
+  # Checks for equality with the object’s \`extra\` field.
+  extra: Boolean
+}
+
+input CompoundKeyInput {
+  personId2: Int!
+  personId1: Int!
+  extra: Boolean
+}
+
+# Represents an update to a \`CompoundKey\`. Fields that are set will be updated.
+input CompoundKeyPatch {
+  personId2: Int
+  personId1: Int
+  extra: Boolean
+}
+
+# A connection to a list of \`CompoundKey\` values.
+type CompoundKeysConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`CompoundKey\` you could get from the connection.
+  totalCount: Int
+
+  # A list of edges which contains the \`CompoundKey\` and cursor to aid in pagination.
+  edges: [CompoundKeysEdge]
+
+  # A list of \`CompoundKey\` objects.
+  nodes: [CompoundKey!]
+}
+
+# A \`CompoundKey\` edge in the connection.
+type CompoundKeysEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`CompoundKey\` at the end of the edge.
+  node: CompoundKey!
+}
+
+# Methods to use when ordering \`CompoundKey\`.
+enum CompoundKeysOrderBy {
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  NATURAL
+  PERSON_ID_2_ASC
+  PERSON_ID_2_DESC
+  PERSON_ID_1_ASC
+  PERSON_ID_1_DESC
+  EXTRA_ASC
+  EXTRA_DESC
+}
+
+# Awesome feature!
+type CompoundType {
+  a: Int
+  b: String
+  c: Color
+  d: Uuid
+  fooBar: Int
+  computedField: Int
+}
+
+# Awesome feature!
+input CompoundTypeInput {
+  a: Int
+  b: String
+  c: Color
+  d: Uuid
+  fooBar: Int
+}
+
+# All input for the \`compoundTypeMutation\` mutation.
+input CompoundTypeMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  object: CompoundTypeInput
+}
+
+# The output of our \`compoundTypeMutation\` mutation.
+type CompoundTypeMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  compoundType: CompoundType
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`createCompoundKey\` mutation.
+input CreateCompoundKeyInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`CompoundKey\` to be created by this mutation.
+  compoundKey: CompoundKeyInput!
+}
+
+# The output of our \`createCompoundKey\` mutation.
+type CreateCompoundKeyPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`CompoundKey\` that was created by this mutation.
+  compoundKey: CompoundKey
+
+  # An edge for our \`CompoundKey\`. May be used by Relay 1.
+  compoundKeyEdge(
+    # The method to use when ordering \`CompoundKey\`.
+    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+  ): CompoundKeysEdge
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId1: Person
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId2: Person
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`createEdgeCase\` mutation.
+input CreateEdgeCaseInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`EdgeCase\` to be created by this mutation.
+  edgeCase: EdgeCaseInput!
+}
+
+# The output of our \`createEdgeCase\` mutation.
+type CreateEdgeCasePayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`EdgeCase\` that was created by this mutation.
+  edgeCase: EdgeCase
+
+  # An edge for our \`EdgeCase\`. May be used by Relay 1.
+  edgeCaseEdge(
+    # The method to use when ordering \`EdgeCase\`.
+    orderBy: EdgeCasesOrderBy = NATURAL
+  ): EdgeCasesEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`createForeignKey\` mutation.
+input CreateForeignKeyInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`ForeignKey\` to be created by this mutation.
+  foreignKey: ForeignKeyInput!
+}
+
+# The output of our \`createForeignKey\` mutation.
+type CreateForeignKeyPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`ForeignKey\` that was created by this mutation.
+  foreignKey: ForeignKey
+
+  # An edge for our \`ForeignKey\`. May be used by Relay 1.
+  foreignKeyEdge(
+    # The method to use when ordering \`ForeignKey\`.
+    orderBy: ForeignKeysOrderBy = NATURAL
+  ): ForeignKeysEdge
+
+  # Reads a single \`CompoundKey\` that is related to this \`ForeignKey\`.
+  compoundKeyByCompoundKey1AndCompoundKey2: CompoundKey
+
+  # Reads a single \`Person\` that is related to this \`ForeignKey\`.
+  personByPersonId: Person
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`createPerson\` mutation.
+input CreatePersonInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`Person\` to be created by this mutation.
+  person: PersonInput!
+}
+
+# The output of our \`createPerson\` mutation.
+type CreatePersonPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`Person\` that was created by this mutation.
+  person: Person
+
+  # An edge for our \`Person\`. May be used by Relay 1.
+  personEdge(
+    # The method to use when ordering \`Person\`.
+    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+  ): PeopleEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`createPost\` mutation.
+input CreatePostInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`Post\` to be created by this mutation.
+  post: PostInput!
+}
+
+# The output of our \`createPost\` mutation.
+type CreatePostPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`Post\` that was created by this mutation.
+  post: Post
+
+  # An edge for our \`Post\`. May be used by Relay 1.
+  postEdge(
+    # The method to use when ordering \`Post\`.
+    orderBy: PostsOrderBy = PRIMARY_KEY_ASC
+  ): PostsEdge
+
+  # Reads a single \`Person\` that is related to this \`Post\`.
+  personByAuthorId: Person
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`createType\` mutation.
+input CreateTypeInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`Type\` to be created by this mutation.
+  type: TypeInput!
+}
+
+# The output of our \`createType\` mutation.
+type CreateTypePayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`Type\` that was created by this mutation.
+  type: Type
+
+  # An edge for our \`Type\`. May be used by Relay 1.
+  typeEdge(
+    # The method to use when ordering \`Type\`.
+    orderBy: TypesOrderBy = PRIMARY_KEY_ASC
+  ): TypesEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`createUpdatableView\` mutation.
+input CreateUpdatableViewInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The \`UpdatableView\` to be created by this mutation.
+  updatableView: UpdatableViewInput!
+}
+
+# The output of our \`createUpdatableView\` mutation.
+type CreateUpdatableViewPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+
+  # The \`UpdatableView\` that was created by this mutation.
+  updatableView: UpdatableView
+
+  # An edge for our \`UpdatableView\`. May be used by Relay 1.
+  updatableViewEdge(
+    # The method to use when ordering \`UpdatableView\`.
+    orderBy: UpdatableViewsOrderBy = NATURAL
+  ): UpdatableViewsEdge
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# A location in a connection that can be used for resuming pagination.
+scalar Cursor
+
+# The day, does not include a time.
+scalar Date
+
+# range of dates
+type DateRange {
+  # The starting bound of our range.
+  start: DateRangeBound
+
+  # The ending bound of our range.
+  end: DateRangeBound
+}
+
+# The value at one end of a range. A range can either include this value, or not.
+type DateRangeBound {
+  # The value at one end of our range.
+  value: Date!
+
+  # Whether or not the value of this bound is included in the range.
+  inclusive: Boolean!
+}
+
+# The value at one end of a range. A range can either include this value, or not.
+input DateRangeBoundInput {
+  # The value at one end of our range.
+  value: Date!
+
+  # Whether or not the value of this bound is included in the range.
+  inclusive: Boolean!
+}
+
+# range of dates
+input DateRangeInput {
+  # The starting bound of our range.
+  start: DateRangeBoundInput
+
+  # The ending bound of our range.
+  end: DateRangeBoundInput
+}
+
+# A point in time as described by the [ISO
+# 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+scalar Datetime
+
+# All input for the \`deleteCompoundKeyByPersonId1AndPersonId2\` mutation.
+input DeleteCompoundKeyByPersonId1AndPersonId2Input {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  personId1: Int!
+  personId2: Int!
+}
+
+# All input for the \`deleteCompoundKey\` mutation.
+input DeleteCompoundKeyInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`CompoundKey\` to be deleted.
+  __id: ID!
+}
+
+# The output of our \`deleteCompoundKey\` mutation.
+type DeleteCompoundKeyPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  compoundKey: CompoundKey
+  deletedCompoundKeyId: ID
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId1: Person
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId2: Person
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`deletePersonByEmail\` mutation.
+input DeletePersonByEmailInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  email: Email!
+}
+
+# All input for the \`deletePersonById\` mutation.
+input DeletePersonByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+}
+
+# All input for the \`deletePerson\` mutation.
+input DeletePersonInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Person\` to be deleted.
+  __id: ID!
+}
+
+# The output of our \`deletePerson\` mutation.
+type DeletePersonPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  person: Person
+  deletedPersonId: ID
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`deletePostById\` mutation.
+input DeletePostByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+}
+
+# All input for the \`deletePost\` mutation.
+input DeletePostInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Post\` to be deleted.
+  __id: ID!
+}
+
+# The output of our \`deletePost\` mutation.
+type DeletePostPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  post: Post
+  deletedPostId: ID
+
+  # Reads a single \`Person\` that is related to this \`Post\`.
+  personByAuthorId: Person
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`deleteTypeById\` mutation.
+input DeleteTypeByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+}
+
+# All input for the \`deleteType\` mutation.
+input DeleteTypeInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Type\` to be deleted.
+  __id: ID!
+}
+
+# The output of our \`deleteType\` mutation.
+type DeleteTypePayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  type: Type
+  deletedTypeId: ID
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+type EdgeCase {
+  notNullHasDefault: Boolean!
+  wontCastEasy: Int
+  rowId: Int
+  computed: String
+}
+
+# A condition to be used against \`EdgeCase\` object types. All fields are tested
+# for equality and combined with a logical ‘and.’
+input EdgeCaseCondition {
+  # Checks for equality with the object’s \`notNullHasDefault\` field.
+  notNullHasDefault: Boolean
+
+  # Checks for equality with the object’s \`wontCastEasy\` field.
+  wontCastEasy: Int
+
+  # Checks for equality with the object’s \`rowId\` field.
+  rowId: Int
+}
+
+input EdgeCaseInput {
+  notNullHasDefault: Boolean
+  wontCastEasy: Int
+  rowId: Int
+}
+
+# A connection to a list of \`EdgeCase\` values.
+type EdgeCasesConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`EdgeCase\` you could get from the connection.
+  totalCount: Int
+
+  # A list of edges which contains the \`EdgeCase\` and cursor to aid in pagination.
+  edges: [EdgeCasesEdge]
+
+  # A list of \`EdgeCase\` objects.
+  nodes: [EdgeCase!]
+}
+
+# A \`EdgeCase\` edge in the connection.
+type EdgeCasesEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`EdgeCase\` at the end of the edge.
+  node: EdgeCase!
+}
+
+# Methods to use when ordering \`EdgeCase\`.
+enum EdgeCasesOrderBy {
+  NATURAL
+  NOT_NULL_HAS_DEFAULT_ASC
+  NOT_NULL_HAS_DEFAULT_DESC
+  WONT_CAST_EASY_ASC
+  WONT_CAST_EASY_DESC
+  ROW_ID_ASC
+  ROW_ID_DESC
+}
+
+scalar Email
+
+# range of numerics
+type FloatRange {
+  # The starting bound of our range.
+  start: FloatRangeBound
+
+  # The ending bound of our range.
+  end: FloatRangeBound
+}
+
+# The value at one end of a range. A range can either include this value, or not.
+type FloatRangeBound {
+  # The value at one end of our range.
+  value: Float!
+
+  # Whether or not the value of this bound is included in the range.
+  inclusive: Boolean!
+}
+
+# The value at one end of a range. A range can either include this value, or not.
+input FloatRangeBoundInput {
+  # The value at one end of our range.
+  value: Float!
+
+  # Whether or not the value of this bound is included in the range.
+  inclusive: Boolean!
+}
+
+# range of numerics
+input FloatRangeInput {
+  # The starting bound of our range.
+  start: FloatRangeBoundInput
+
+  # The ending bound of our range.
+  end: FloatRangeBoundInput
+}
+
+type ForeignKey {
+  personId: Int
+  compoundKey1: Int
+  compoundKey2: Int
+
+  # Reads a single \`CompoundKey\` that is related to this \`ForeignKey\`.
+  compoundKeyByCompoundKey1AndCompoundKey2: CompoundKey
+
+  # Reads a single \`Person\` that is related to this \`ForeignKey\`.
+  personByPersonId: Person
+}
+
+# A condition to be used against \`ForeignKey\` object types. All fields are tested
+# for equality and combined with a logical ‘and.’
+input ForeignKeyCondition {
+  # Checks for equality with the object’s \`personId\` field.
+  personId: Int
+
+  # Checks for equality with the object’s \`compoundKey1\` field.
+  compoundKey1: Int
+
+  # Checks for equality with the object’s \`compoundKey2\` field.
+  compoundKey2: Int
+}
+
+input ForeignKeyInput {
+  personId: Int
+  compoundKey1: Int
+  compoundKey2: Int
+}
+
+# A connection to a list of \`ForeignKey\` values.
+type ForeignKeysConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`ForeignKey\` you could get from the connection.
+  totalCount: Int
+
+  # A list of edges which contains the \`ForeignKey\` and cursor to aid in pagination.
+  edges: [ForeignKeysEdge]
+
+  # A list of \`ForeignKey\` objects.
+  nodes: [ForeignKey!]
+}
+
+# A \`ForeignKey\` edge in the connection.
+type ForeignKeysEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`ForeignKey\` at the end of the edge.
+  node: ForeignKey!
+}
+
+# Methods to use when ordering \`ForeignKey\`.
+enum ForeignKeysOrderBy {
+  NATURAL
+  PERSON_ID_ASC
+  PERSON_ID_DESC
+  COMPOUND_KEY_1_ASC
+  COMPOUND_KEY_1_DESC
+  COMPOUND_KEY_2_ASC
+  COMPOUND_KEY_2_DESC
+}
+
+# An interval of time that has passed where the smallest distinct unit is a second.
+type Interval {
+  # A quantity of seconds. This is the only non-integer field, as all the other
+  # fields will dump their overflow into a smaller unit of time. Intervals don’t
+  # have a smaller unit than seconds.
+  seconds: Float
+
+  # A quantity of minutes.
+  minutes: Int
+
+  # A quantity of hours.
+  hours: Int
+
+  # A quantity of days.
+  days: Int
+
+  # A quantity of months
+  months: Int
+
+  # A quantity of years
+  years: Int
+}
+
+# An interval of time that has passed where the smallest distinct unit is a second.
+input IntervalInput {
+  # A quantity of seconds. This is the only non-integer field, as all the other
+  # fields will dump their overflow into a smaller unit of time. Intervals don’t
+  # have a smaller unit than seconds.
+  seconds: Float
+
+  # A quantity of minutes.
+  minutes: Int
+
+  # A quantity of hours.
+  hours: Int
+
+  # A quantity of days.
+  days: Int
+
+  # A quantity of months
+  months: Int
+
+  # A quantity of years
+  years: Int
+}
+
+# All input for the \`intSetMutation\` mutation.
+input IntSetMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  x: Int
+  y: Int
+  z: Int
+}
+
+# The output of our \`intSetMutation\` mutation.
+type IntSetMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integers: [Int]
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# A connection to a list of \`Int\` values.
+type IntSetQueryConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`Int\` you could get from the connection.
+  totalCount: Int
+
+  # A list of edges which contains the \`Int\` and cursor to aid in pagination.
+  edges: [IntSetQueryEdge]
+
+  # A list of \`Int\` objects.
+  nodes: [Int]
+}
+
+# A \`Int\` edge in the connection.
+type IntSetQueryEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Int\` at the end of the edge.
+  node: Int
+}
+
+# Methods to use when ordering \`Int\`.
+enum IntSetQueryOrderBy {
+  NATURAL
+}
+
+# A JavaScript object encoded in the JSON format as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+scalar Json
+
+# All input for the \`jsonIdentityMutation\` mutation.
+input JsonIdentityMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  json: Json
+}
+
+# The output of our \`jsonIdentityMutation\` mutation.
+type JsonIdentityMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  json: Json
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+type JwtToken {
+  role: String
+  exp: Int
+  a: Int
+  b: Int
+  c: Int
+}
+
+# All input for the \`mult1\` mutation.
+input Mult1Input {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  arg0: Int
+  arg1: Int
+}
+
+# The output of our \`mult1\` mutation.
+type Mult1Payload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`mult2\` mutation.
+input Mult2Input {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  arg0: Int
+  arg1: Int
+}
+
+# The output of our \`mult2\` mutation.
+type Mult2Payload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`mult3\` mutation.
+input Mult3Input {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  arg0: Int!
+  arg1: Int!
+}
+
+# The output of our \`mult3\` mutation.
+type Mult3Payload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`mult4\` mutation.
+input Mult4Input {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  arg0: Int!
+  arg1: Int!
+}
+
+# The output of our \`mult4\` mutation.
+type Mult4Payload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# The root mutation type which contains root level fields which mutate data.
+type Mutation {
+  # lol, add some stuff 1 mutation
+  add1Mutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: Add1MutationInput!
+  ): Add1MutationPayload
+
+  # lol, add some stuff 2 mutation
+  add2Mutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: Add2MutationInput!
+  ): Add2MutationPayload
+
+  # lol, add some stuff 3 mutation
+  add3Mutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: Add3MutationInput!
+  ): Add3MutationPayload
+
+  # lol, add some stuff 4 mutation
+  add4Mutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: Add4MutationInput!
+  ): Add4MutationPayload
+  authenticate(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: AuthenticateInput!
+  ): AuthenticatePayload
+  authenticateMany(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: AuthenticateManyInput!
+  ): AuthenticateManyPayload
+  compoundTypeMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CompoundTypeMutationInput!
+  ): CompoundTypeMutationPayload
+  mult1(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: Mult1Input!
+  ): Mult1Payload
+  mult2(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: Mult2Input!
+  ): Mult2Payload
+  mult3(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: Mult3Input!
+  ): Mult3Payload
+  mult4(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: Mult4Input!
+  ): Mult4Payload
+  intSetMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: IntSetMutationInput!
+  ): IntSetMutationPayload
+  jsonIdentityMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: JsonIdentityMutationInput!
+  ): JsonIdentityMutationPayload
+  noArgsMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: NoArgsMutationInput!
+  ): NoArgsMutationPayload
+  tableMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: TableMutationInput!
+  ): TableMutationPayload
+  tableSetMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: TableSetMutationInput!
+  ): TableSetMutationPayload
+  typesMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: TypesMutationInput!
+  ): TypesMutationPayload
+
+  # Creates a single \`ForeignKey\`.
+  createForeignKey(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateForeignKeyInput!
+  ): CreateForeignKeyPayload
+
+  # Creates a single \`Post\`.
+  createPost(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreatePostInput!
+  ): CreatePostPayload
+
+  # Updates a single \`Post\` using its globally unique id and a patch.
+  updatePost(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdatePostInput!
+  ): UpdatePostPayload
+
+  # Updates a single \`Post\` using a unique key and a patch.
+  updatePostById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdatePostByIdInput!
+  ): UpdatePostPayload
+
+  # Deletes a single \`Post\` using its globally unique id.
+  deletePost(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeletePostInput!
+  ): DeletePostPayload
+
+  # Deletes a single \`Post\` using a unique key.
+  deletePostById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeletePostByIdInput!
+  ): DeletePostPayload
+
+  # Creates a single \`Type\`.
+  createType(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateTypeInput!
+  ): CreateTypePayload
+
+  # Updates a single \`Type\` using its globally unique id and a patch.
+  updateType(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateTypeInput!
+  ): UpdateTypePayload
+
+  # Updates a single \`Type\` using a unique key and a patch.
+  updateTypeById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateTypeByIdInput!
+  ): UpdateTypePayload
+
+  # Deletes a single \`Type\` using its globally unique id.
+  deleteType(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteTypeInput!
+  ): DeleteTypePayload
+
+  # Deletes a single \`Type\` using a unique key.
+  deleteTypeById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteTypeByIdInput!
+  ): DeleteTypePayload
+
+  # Creates a single \`UpdatableView\`.
+  createUpdatableView(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateUpdatableViewInput!
+  ): CreateUpdatableViewPayload
+
+  # Creates a single \`CompoundKey\`.
+  createCompoundKey(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateCompoundKeyInput!
+  ): CreateCompoundKeyPayload
+
+  # Updates a single \`CompoundKey\` using its globally unique id and a patch.
+  updateCompoundKey(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateCompoundKeyInput!
+  ): UpdateCompoundKeyPayload
+
+  # Updates a single \`CompoundKey\` using a unique key and a patch.
+  updateCompoundKeyByPersonId1AndPersonId2(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdateCompoundKeyByPersonId1AndPersonId2Input!
+  ): UpdateCompoundKeyPayload
+
+  # Deletes a single \`CompoundKey\` using its globally unique id.
+  deleteCompoundKey(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteCompoundKeyInput!
+  ): DeleteCompoundKeyPayload
+
+  # Deletes a single \`CompoundKey\` using a unique key.
+  deleteCompoundKeyByPersonId1AndPersonId2(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeleteCompoundKeyByPersonId1AndPersonId2Input!
+  ): DeleteCompoundKeyPayload
+
+  # Creates a single \`EdgeCase\`.
+  createEdgeCase(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreateEdgeCaseInput!
+  ): CreateEdgeCasePayload
+
+  # Creates a single \`Person\`.
+  createPerson(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: CreatePersonInput!
+  ): CreatePersonPayload
+
+  # Updates a single \`Person\` using its globally unique id and a patch.
+  updatePerson(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdatePersonInput!
+  ): UpdatePersonPayload
+
+  # Updates a single \`Person\` using a unique key and a patch.
+  updatePersonByEmail(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdatePersonByEmailInput!
+  ): UpdatePersonPayload
+
+  # Updates a single \`Person\` using a unique key and a patch.
+  updatePersonById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: UpdatePersonByIdInput!
+  ): UpdatePersonPayload
+
+  # Deletes a single \`Person\` using its globally unique id.
+  deletePerson(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeletePersonInput!
+  ): DeletePersonPayload
+
+  # Deletes a single \`Person\` using a unique key.
+  deletePersonByEmail(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeletePersonByEmailInput!
+  ): DeletePersonPayload
+
+  # Deletes a single \`Person\` using a unique key.
+  deletePersonById(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: DeletePersonByIdInput!
+  ): DeletePersonPayload
+}
+
+type NestedCompoundType {
+  a: CompoundType
+  b: CompoundType
+  bazBuz: Int
+}
+
+input NestedCompoundTypeInput {
+  a: CompoundTypeInput
+  b: CompoundTypeInput
+  bazBuz: Int
+}
+
+# All input for the \`noArgsMutation\` mutation.
+input NoArgsMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`noArgsMutation\` mutation.
+type NoArgsMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# An object with a globally unique \`ID\`.
+interface Node {
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  __id: ID!
+}
+
+type NonUpdatableView {
+  column: Int
+}
+
+# A condition to be used against \`NonUpdatableView\` object types. All fields are
+# tested for equality and combined with a logical ‘and.’
+input NonUpdatableViewCondition {
+  # Checks for equality with the object’s \`column\` field.
+  column: Int
+}
+
+# A connection to a list of \`NonUpdatableView\` values.
+type NonUpdatableViewsConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`NonUpdatableView\` you could get from the connection.
+  totalCount: Int
+
+  # A list of edges which contains the \`NonUpdatableView\` and cursor to aid in pagination.
+  edges: [NonUpdatableViewsEdge]
+
+  # A list of \`NonUpdatableView\` objects.
+  nodes: [NonUpdatableView!]
+}
+
+# A \`NonUpdatableView\` edge in the connection.
+type NonUpdatableViewsEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`NonUpdatableView\` at the end of the edge.
+  node: NonUpdatableView!
+}
+
+# Methods to use when ordering \`NonUpdatableView\`.
+enum NonUpdatableViewsOrderBy {
+  NATURAL
+  COLUMN_ASC
+  COLUMN_DESC
+}
+
+# Information about pagination in a connection.
+type PageInfo {
+  # When paginating forwards, are there more items?
+  hasNextPage: Boolean!
+
+  # When paginating backwards, are there more items?
+  hasPreviousPage: Boolean!
+
+  # When paginating backwards, the cursor to continue.
+  startCursor: Cursor
+
+  # When paginating forwards, the cursor to continue.
+  endCursor: Cursor
+}
+
+# A connection to a list of \`Person\` values.
+type PeopleConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`Person\` you could get from the connection.
+  totalCount: Int
+
+  # A list of edges which contains the \`Person\` and cursor to aid in pagination.
+  edges: [PeopleEdge]
+
+  # A list of \`Person\` objects.
+  nodes: [Person!]
+}
+
+# A \`Person\` edge in the connection.
+type PeopleEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Person\` at the end of the edge.
+  node: Person!
+}
+
+# Methods to use when ordering \`Person\`.
+enum PeopleOrderBy {
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  NATURAL
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  ABOUT_ASC
+  ABOUT_DESC
+  EMAIL_ASC
+  EMAIL_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+}
+
+# Person test comment
+type Person implements Node {
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  __id: ID!
+  id: Int!
+
+  # The person’s name
+  name: String!
+  about: String
+  email: Email!
+  createdAt: Datetime
+  firstName: String
+
+  # Reads and enables paginatation through a set of \`Person\`.
+  friends(
+    # The method to use when ordering \`Person\`.
+    orderBy: PersonFriendsOrderBy = NATURAL
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+  ): PersonFriendsConnection
+
+  # Reads and enables paginatation through a set of \`Post\`.
+  postsByAuthorId(
+    # The method to use when ordering \`Post\`.
+    orderBy: PostsOrderBy = PRIMARY_KEY_ASC
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+  ): PostsConnection
+
+  # Reads and enables paginatation through a set of \`CompoundKey\`.
+  compoundKeysByPersonId1(
+    # The method to use when ordering \`CompoundKey\`.
+    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+  ): CompoundKeysConnection
+
+  # Reads and enables paginatation through a set of \`CompoundKey\`.
+  compoundKeysByPersonId2(
+    # The method to use when ordering \`CompoundKey\`.
+    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+  ): CompoundKeysConnection
+
+  # Reads and enables paginatation through a set of \`ForeignKey\`.
+  foreignKeysByPersonId(
+    # The method to use when ordering \`ForeignKey\`.
+    orderBy: ForeignKeysOrderBy = NATURAL
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+  ): ForeignKeysConnection
+}
+
+# A condition to be used against \`Person\` object types. All fields are tested for equality and combined with a logical ‘and.’
+input PersonCondition {
+  # Checks for equality with the object’s \`id\` field.
+  id: Int
+
+  # Checks for equality with the object’s \`name\` field.
+  name: String
+
+  # Checks for equality with the object’s \`about\` field.
+  about: String
+
+  # Checks for equality with the object’s \`email\` field.
+  email: Email
+
+  # Checks for equality with the object’s \`createdAt\` field.
+  createdAt: Datetime
+}
+
+# A connection to a list of \`Person\` values.
+type PersonFriendsConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`Person\` you could get from the connection.
+  totalCount: Int
+
+  # A list of edges which contains the \`Person\` and cursor to aid in pagination.
+  edges: [PersonFriendsEdge]
+
+  # A list of \`Person\` objects.
+  nodes: [Person]
+}
+
+# A \`Person\` edge in the connection.
+type PersonFriendsEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Person\` at the end of the edge.
+  node: Person
+}
+
+# Methods to use when ordering \`Person\`.
+enum PersonFriendsOrderBy {
+  NATURAL
+}
+
+# Person test comment
+input PersonInput {
+  id: Int
+
+  # The person’s name
+  name: String!
+  about: String
+  email: Email!
+  createdAt: Datetime
+}
+
+# Represents an update to a \`Person\`. Fields that are set will be updated.
+input PersonPatch {
+  id: Int
+
+  # The person’s name
+  name: String
+  about: String
+  email: Email
+  createdAt: Datetime
+}
+
+type Post implements Node {
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  __id: ID!
+  id: Int!
+  headline: String!
+  body: String
+  authorId: Int
+  headlineTrimmed(length: Int, omission: String): String
+
+  # Reads a single \`Person\` that is related to this \`Post\`.
+  personByAuthorId: Person
+}
+
+# A condition to be used against \`Post\` object types. All fields are tested for equality and combined with a logical ‘and.’
+input PostCondition {
+  # Checks for equality with the object’s \`id\` field.
+  id: Int
+
+  # Checks for equality with the object’s \`headline\` field.
+  headline: String
+
+  # Checks for equality with the object’s \`body\` field.
+  body: String
+
+  # Checks for equality with the object’s \`authorId\` field.
+  authorId: Int
+}
+
+input PostInput {
+  id: Int
+  headline: String!
+  body: String
+  authorId: Int
+}
+
+# Represents an update to a \`Post\`. Fields that are set will be updated.
+input PostPatch {
+  id: Int
+  headline: String
+  body: String
+  authorId: Int
+}
+
+# A connection to a list of \`Post\` values.
+type PostsConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`Post\` you could get from the connection.
+  totalCount: Int
+
+  # A list of edges which contains the \`Post\` and cursor to aid in pagination.
+  edges: [PostsEdge]
+
+  # A list of \`Post\` objects.
+  nodes: [Post!]
+}
+
+# A \`Post\` edge in the connection.
+type PostsEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Post\` at the end of the edge.
+  node: Post!
+}
+
+# Methods to use when ordering \`Post\`.
+enum PostsOrderBy {
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  NATURAL
+  ID_ASC
+  ID_DESC
+  HEADLINE_ASC
+  HEADLINE_DESC
+  BODY_ASC
+  BODY_DESC
+  AUTHOR_ID_ASC
+  AUTHOR_ID_DESC
+}
+
+# The root query type which gives access points into the data universe.
+type Query implements Node {
+  # Fetches an object given its globally unique \`ID\`.
+  node(
+    # The globally unique \`ID\`.
+    __id: ID!
+  ): Node
+
+  # lol, add some stuff 1 query
+  add1Query(arg0: Int!, arg1: Int!): Int
+
+  # lol, add some stuff 2 query
+  add2Query(a: Int!, b: Int!): Int
+
+  # lol, add some stuff 3 query
+  add3Query(a: Int, arg1: Int): Int
+
+  # lol, add some stuff 4 query
+  add4Query(arg0: Int, b: Int): Int
+  compoundTypeQuery(object: CompoundTypeInput): CompoundType
+
+  # Reads and enables paginatation through a set of \`Int\`.
+  intSetQuery(
+    # The method to use when ordering \`Int\`.
+    orderBy: IntSetQueryOrderBy = NATURAL
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+    x: Int
+    y: Int
+    z: Int
+  ): IntSetQueryConnection
+  jsonIdentity(json: Json): Json
+  noArgsQuery: Int
+  tableQuery(id: Int): Post
+
+  # Reads and enables paginatation through a set of \`Person\`.
+  tableSetQuery(
+    # The method to use when ordering \`Person\`.
+    orderBy: TableSetQueryOrderBy = NATURAL
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+  ): TableSetQueryConnection
+  typesQuery(a: Int!, b: Boolean!, c: String!, d: [Int]!, e: Json!, f: FloatRangeInput!): Boolean
+
+  # Reads and enables paginatation through a set of \`ForeignKey\`.
+  allForeignKeys(
+    # The method to use when ordering \`ForeignKey\`.
+    orderBy: ForeignKeysOrderBy = NATURAL
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: ForeignKeyCondition
+  ): ForeignKeysConnection
+
+  # Reads and enables paginatation through a set of \`NonUpdatableView\`.
+  allNonUpdatableViews(
+    # The method to use when ordering \`NonUpdatableView\`.
+    orderBy: NonUpdatableViewsOrderBy = NATURAL
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: NonUpdatableViewCondition
+  ): NonUpdatableViewsConnection
+
+  # Reads and enables paginatation through a set of \`Post\`.
+  allPosts(
+    # The method to use when ordering \`Post\`.
+    orderBy: PostsOrderBy = PRIMARY_KEY_ASC
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: PostCondition
+  ): PostsConnection
+
+  # Reads a single \`Post\` using its globally unique \`ID\`.
+  post(
+    # The globally unique \`ID\` to be used in selecting a single \`Post\`.
+    __id: ID!
+  ): Post
+  postById(id: Int!): Post
+
+  # Reads and enables paginatation through a set of \`Type\`.
+  allTypes(
+    # The method to use when ordering \`Type\`.
+    orderBy: TypesOrderBy = PRIMARY_KEY_ASC
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: TypeCondition
+  ): TypesConnection
+
+  # Reads a single \`Type\` using its globally unique \`ID\`.
+  type(
+    # The globally unique \`ID\` to be used in selecting a single \`Type\`.
+    __id: ID!
+  ): Type
+  typeById(id: Int!): Type
+
+  # Reads and enables paginatation through a set of \`UpdatableView\`.
+  allUpdatableViews(
+    # The method to use when ordering \`UpdatableView\`.
+    orderBy: UpdatableViewsOrderBy = NATURAL
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: UpdatableViewCondition
+  ): UpdatableViewsConnection
+
+  # Reads and enables paginatation through a set of \`CompoundKey\`.
+  allCompoundKeys(
+    # The method to use when ordering \`CompoundKey\`.
+    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: CompoundKeyCondition
+  ): CompoundKeysConnection
+
+  # Reads a single \`CompoundKey\` using its globally unique \`ID\`.
+  compoundKey(
+    # The globally unique \`ID\` to be used in selecting a single \`CompoundKey\`.
+    __id: ID!
+  ): CompoundKey
+  compoundKeyByPersonId1AndPersonId2(personId1: Int!, personId2: Int!): CompoundKey
+
+  # Reads and enables paginatation through a set of \`EdgeCase\`.
+  allEdgeCases(
+    # The method to use when ordering \`EdgeCase\`.
+    orderBy: EdgeCasesOrderBy = NATURAL
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: EdgeCaseCondition
+  ): EdgeCasesConnection
+
+  # Reads and enables paginatation through a set of \`Person\`.
+  allPeople(
+    # The method to use when ordering \`Person\`.
+    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: PersonCondition
+  ): PeopleConnection
+
+  # Reads a single \`Person\` using its globally unique \`ID\`.
+  person(
+    # The globally unique \`ID\` to be used in selecting a single \`Person\`.
+    __id: ID!
+  ): Person
+  personByEmail(email: Email!): Person
+  personById(id: Int!): Person
+
+  # Exposes the root query type nested one level down. This is helpful for Relay 1
+  # which can only query top level fields if they are in a particular form.
+  query: Query!
+
+  # The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  __id: ID!
+}
+
+# All input for the \`tableMutation\` mutation.
+input TableMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int
+}
+
+# The output of our \`tableMutation\` mutation.
+type TableMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  post: Post
+
+  # Reads a single \`Person\` that is related to this \`Post\`.
+  personByAuthorId: Person
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`tableSetMutation\` mutation.
+input TableSetMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`tableSetMutation\` mutation.
+type TableSetMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  people: [Person]
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# A connection to a list of \`Person\` values.
+type TableSetQueryConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`Person\` you could get from the connection.
+  totalCount: Int
+
+  # A list of edges which contains the \`Person\` and cursor to aid in pagination.
+  edges: [TableSetQueryEdge]
+
+  # A list of \`Person\` objects.
+  nodes: [Person]
+}
+
+# A \`Person\` edge in the connection.
+type TableSetQueryEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Person\` at the end of the edge.
+  node: Person
+}
+
+# Methods to use when ordering \`Person\`.
+enum TableSetQueryOrderBy {
+  NATURAL
+}
+
+# The exact time of day, does not include the date. May or may not have a timezone offset.
+scalar Time
+
+type Type implements Node {
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  __id: ID!
+  id: Int!
+  smallint: Int!
+  bigint: Int!
+  boolean: Boolean!
+  varchar: String!
+  enum: Color!
+  domain: AnInt!
+  domain2: AnotherInt!
+  textArray: [String]!
+  json: Json!
+  jsonb: Json!
+  numrange: FloatRange!
+  daterange: DateRange!
+  anIntRange: AnIntRange!
+  timestamp: Datetime!
+  timestamptz: Datetime!
+  date: Date!
+  time: Time!
+  timetz: Time!
+  interval: Interval!
+  money: Float!
+  compoundType: CompoundType!
+  nestedCompoundType: NestedCompoundType!
+}
+
+# A condition to be used against \`Type\` object types. All fields are tested for equality and combined with a logical ‘and.’
+input TypeCondition {
+  # Checks for equality with the object’s \`id\` field.
+  id: Int
+
+  # Checks for equality with the object’s \`smallint\` field.
+  smallint: Int
+
+  # Checks for equality with the object’s \`bigint\` field.
+  bigint: Int
+
+  # Checks for equality with the object’s \`boolean\` field.
+  boolean: Boolean
+
+  # Checks for equality with the object’s \`varchar\` field.
+  varchar: String
+
+  # Checks for equality with the object’s \`enum\` field.
+  enum: Color
+
+  # Checks for equality with the object’s \`domain\` field.
+  domain: AnInt
+
+  # Checks for equality with the object’s \`domain2\` field.
+  domain2: AnotherInt
+
+  # Checks for equality with the object’s \`textArray\` field.
+  textArray: [String]
+
+  # Checks for equality with the object’s \`json\` field.
+  json: Json
+
+  # Checks for equality with the object’s \`jsonb\` field.
+  jsonb: Json
+
+  # Checks for equality with the object’s \`numrange\` field.
+  numrange: FloatRangeInput
+
+  # Checks for equality with the object’s \`daterange\` field.
+  daterange: DateRangeInput
+
+  # Checks for equality with the object’s \`anIntRange\` field.
+  anIntRange: AnIntRangeInput
+
+  # Checks for equality with the object’s \`timestamp\` field.
+  timestamp: Datetime
+
+  # Checks for equality with the object’s \`timestamptz\` field.
+  timestamptz: Datetime
+
+  # Checks for equality with the object’s \`date\` field.
+  date: Date
+
+  # Checks for equality with the object’s \`time\` field.
+  time: Time
+
+  # Checks for equality with the object’s \`timetz\` field.
+  timetz: Time
+
+  # Checks for equality with the object’s \`interval\` field.
+  interval: IntervalInput
+
+  # Checks for equality with the object’s \`money\` field.
+  money: Float
+
+  # Checks for equality with the object’s \`compoundType\` field.
+  compoundType: CompoundTypeInput
+
+  # Checks for equality with the object’s \`nestedCompoundType\` field.
+  nestedCompoundType: NestedCompoundTypeInput
+}
+
+input TypeInput {
+  id: Int
+  smallint: Int!
+  bigint: Int!
+  boolean: Boolean!
+  varchar: String!
+  enum: Color!
+  domain: AnInt!
+  domain2: AnotherInt!
+  textArray: [String]!
+  json: Json!
+  jsonb: Json!
+  numrange: FloatRangeInput!
+  daterange: DateRangeInput!
+  anIntRange: AnIntRangeInput!
+  timestamp: Datetime!
+  timestamptz: Datetime!
+  date: Date!
+  time: Time!
+  timetz: Time!
+  interval: IntervalInput!
+  money: Float!
+  compoundType: CompoundTypeInput!
+  nestedCompoundType: NestedCompoundTypeInput!
+}
+
+# Represents an update to a \`Type\`. Fields that are set will be updated.
+input TypePatch {
+  id: Int
+  smallint: Int
+  bigint: Int
+  boolean: Boolean
+  varchar: String
+  enum: Color
+  domain: AnInt
+  domain2: AnotherInt
+  textArray: [String]
+  json: Json
+  jsonb: Json
+  numrange: FloatRangeInput
+  daterange: DateRangeInput
+  anIntRange: AnIntRangeInput
+  timestamp: Datetime
+  timestamptz: Datetime
+  date: Date
+  time: Time
+  timetz: Time
+  interval: IntervalInput
+  money: Float
+  compoundType: CompoundTypeInput
+  nestedCompoundType: NestedCompoundTypeInput
+}
+
+# A connection to a list of \`Type\` values.
+type TypesConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`Type\` you could get from the connection.
+  totalCount: Int
+
+  # A list of edges which contains the \`Type\` and cursor to aid in pagination.
+  edges: [TypesEdge]
+
+  # A list of \`Type\` objects.
+  nodes: [Type!]
+}
+
+# A \`Type\` edge in the connection.
+type TypesEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Type\` at the end of the edge.
+  node: Type!
+}
+
+# All input for the \`typesMutation\` mutation.
+input TypesMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  a: Int!
+  b: Boolean!
+  c: String!
+  d: [Int]!
+  e: Json!
+  f: FloatRangeInput!
+}
+
+# The output of our \`typesMutation\` mutation.
+type TypesMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  boolean: Boolean
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# Methods to use when ordering \`Type\`.
+enum TypesOrderBy {
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  NATURAL
+  ID_ASC
+  ID_DESC
+  SMALLINT_ASC
+  SMALLINT_DESC
+  BIGINT_ASC
+  BIGINT_DESC
+  BOOLEAN_ASC
+  BOOLEAN_DESC
+  VARCHAR_ASC
+  VARCHAR_DESC
+  ENUM_ASC
+  ENUM_DESC
+  DOMAIN_ASC
+  DOMAIN_DESC
+  DOMAIN2_ASC
+  DOMAIN2_DESC
+  TEXT_ARRAY_ASC
+  TEXT_ARRAY_DESC
+  JSON_ASC
+  JSON_DESC
+  JSONB_ASC
+  JSONB_DESC
+  NUMRANGE_ASC
+  NUMRANGE_DESC
+  DATERANGE_ASC
+  DATERANGE_DESC
+  AN_INT_RANGE_ASC
+  AN_INT_RANGE_DESC
+  TIMESTAMP_ASC
+  TIMESTAMP_DESC
+  TIMESTAMPTZ_ASC
+  TIMESTAMPTZ_DESC
+  DATE_ASC
+  DATE_DESC
+  TIME_ASC
+  TIME_DESC
+  TIMETZ_ASC
+  TIMETZ_DESC
+  INTERVAL_ASC
+  INTERVAL_DESC
+  MONEY_ASC
+  MONEY_DESC
+  COMPOUND_TYPE_ASC
+  COMPOUND_TYPE_DESC
+  NESTED_COMPOUND_TYPE_ASC
+  NESTED_COMPOUND_TYPE_DESC
+}
+
+# YOYOYO!!
+type UpdatableView {
+  x: Int
+  name: String
+  description: String
+
+  # This is constantly 2
+  constant: Int
+}
+
+# A condition to be used against \`UpdatableView\` object types. All fields are
+# tested for equality and combined with a logical ‘and.’
+input UpdatableViewCondition {
+  # Checks for equality with the object’s \`x\` field.
+  x: Int
+
+  # Checks for equality with the object’s \`name\` field.
+  name: String
+
+  # Checks for equality with the object’s \`description\` field.
+  description: String
+
+  # Checks for equality with the object’s \`constant\` field.
+  constant: Int
+}
+
+# YOYOYO!!
+input UpdatableViewInput {
+  x: Int
+  name: String
+  description: String
+
+  # This is constantly 2
+  constant: Int
+}
+
+# A connection to a list of \`UpdatableView\` values.
+type UpdatableViewsConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`UpdatableView\` you could get from the connection.
+  totalCount: Int
+
+  # A list of edges which contains the \`UpdatableView\` and cursor to aid in pagination.
+  edges: [UpdatableViewsEdge]
+
+  # A list of \`UpdatableView\` objects.
+  nodes: [UpdatableView!]
+}
+
+# A \`UpdatableView\` edge in the connection.
+type UpdatableViewsEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`UpdatableView\` at the end of the edge.
+  node: UpdatableView!
+}
+
+# Methods to use when ordering \`UpdatableView\`.
+enum UpdatableViewsOrderBy {
+  NATURAL
+  X_ASC
+  X_DESC
+  NAME_ASC
+  NAME_DESC
+  DESCRIPTION_ASC
+  DESCRIPTION_DESC
+  CONSTANT_ASC
+  CONSTANT_DESC
+}
+
+# All input for the \`updateCompoundKeyByPersonId1AndPersonId2\` mutation.
+input UpdateCompoundKeyByPersonId1AndPersonId2Input {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  personId1: Int!
+  personId2: Int!
+
+  # An object where the defined keys will be set on the \`CompoundKey\` identified by our unique key.
+  compoundKeyPatch: CompoundKeyPatch!
+}
+
+# All input for the \`updateCompoundKey\` mutation.
+input UpdateCompoundKeyInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`CompoundKey\` to be updated.
+  __id: ID!
+
+  # An object where the defined keys will be set on the \`CompoundKey\` identified by our globally unique \`ID\`.
+  compoundKeyPatch: CompoundKeyPatch!
+}
+
+# The output of our \`updateCompoundKey\` mutation.
+type UpdateCompoundKeyPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  compoundKey: CompoundKey
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId1: Person
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId2: Person
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`updatePersonByEmail\` mutation.
+input UpdatePersonByEmailInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  email: Email!
+
+  # An object where the defined keys will be set on the \`Person\` identified by our unique key.
+  personPatch: PersonPatch!
+}
+
+# All input for the \`updatePersonById\` mutation.
+input UpdatePersonByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+
+  # An object where the defined keys will be set on the \`Person\` identified by our unique key.
+  personPatch: PersonPatch!
+}
+
+# All input for the \`updatePerson\` mutation.
+input UpdatePersonInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Person\` to be updated.
+  __id: ID!
+
+  # An object where the defined keys will be set on the \`Person\` identified by our globally unique \`ID\`.
+  personPatch: PersonPatch!
+}
+
+# The output of our \`updatePerson\` mutation.
+type UpdatePersonPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  person: Person
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`updatePostById\` mutation.
+input UpdatePostByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+
+  # An object where the defined keys will be set on the \`Post\` identified by our unique key.
+  postPatch: PostPatch!
+}
+
+# All input for the \`updatePost\` mutation.
+input UpdatePostInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Post\` to be updated.
+  __id: ID!
+
+  # An object where the defined keys will be set on the \`Post\` identified by our globally unique \`ID\`.
+  postPatch: PostPatch!
+}
+
+# The output of our \`updatePost\` mutation.
+type UpdatePostPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  post: Post
+
+  # Reads a single \`Person\` that is related to this \`Post\`.
+  personByAuthorId: Person
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`updateTypeById\` mutation.
+input UpdateTypeByIdInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int!
+
+  # An object where the defined keys will be set on the \`Type\` identified by our unique key.
+  typePatch: TypePatch!
+}
+
+# All input for the \`updateType\` mutation.
+input UpdateTypeInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+
+  # The globally unique \`ID\` which will identify a single \`Type\` to be updated.
+  __id: ID!
+
+  # An object where the defined keys will be set on the \`Type\` identified by our globally unique \`ID\`.
+  typePatch: TypePatch!
+}
+
+# The output of our \`updateType\` mutation.
+type UpdateTypePayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  type: Type
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
+scalar Uuid
+"
+`;
+
+exports[`test prints a schema with Relay 1 style ids 2`] = `
 "type CompoundKey implements Node {
   # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   id: ID!
@@ -4617,5 +7206,715 @@ type UpdateTypePayload {
 
 # A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
 scalar Uuid
+"
+`;
+
+exports[`test prints a schema without default mutations 1`] = `
+"type CompoundKey implements Node {
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  __id: ID!
+  personId2: Int!
+  personId1: Int!
+  extra: Boolean
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId1: Person
+
+  # Reads a single \`Person\` that is related to this \`CompoundKey\`.
+  personByPersonId2: Person
+}
+
+# A condition to be used against \`CompoundKey\` object types. All fields are tested
+# for equality and combined with a logical ‘and.’
+input CompoundKeyCondition {
+  # Checks for equality with the object’s \`personId2\` field.
+  personId2: Int
+
+  # Checks for equality with the object’s \`personId1\` field.
+  personId1: Int
+
+  # Checks for equality with the object’s \`extra\` field.
+  extra: Boolean
+}
+
+# A connection to a list of \`CompoundKey\` values.
+type CompoundKeysConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`CompoundKey\` you could get from the connection.
+  totalCount: Int
+
+  # A list of edges which contains the \`CompoundKey\` and cursor to aid in pagination.
+  edges: [CompoundKeysEdge]
+
+  # A list of \`CompoundKey\` objects.
+  nodes: [CompoundKey!]
+}
+
+# A \`CompoundKey\` edge in the connection.
+type CompoundKeysEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`CompoundKey\` at the end of the edge.
+  node: CompoundKey!
+}
+
+# Methods to use when ordering \`CompoundKey\`.
+enum CompoundKeysOrderBy {
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  NATURAL
+  PERSON_ID_2_ASC
+  PERSON_ID_2_DESC
+  PERSON_ID_1_ASC
+  PERSON_ID_1_DESC
+  EXTRA_ASC
+  EXTRA_DESC
+}
+
+# A location in a connection that can be used for resuming pagination.
+scalar Cursor
+
+# A point in time as described by the [ISO
+# 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+scalar Datetime
+
+type EdgeCase {
+  notNullHasDefault: Boolean!
+  wontCastEasy: Int
+  rowId: Int
+  computed: String
+}
+
+# A condition to be used against \`EdgeCase\` object types. All fields are tested
+# for equality and combined with a logical ‘and.’
+input EdgeCaseCondition {
+  # Checks for equality with the object’s \`notNullHasDefault\` field.
+  notNullHasDefault: Boolean
+
+  # Checks for equality with the object’s \`wontCastEasy\` field.
+  wontCastEasy: Int
+
+  # Checks for equality with the object’s \`rowId\` field.
+  rowId: Int
+}
+
+# A connection to a list of \`EdgeCase\` values.
+type EdgeCasesConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`EdgeCase\` you could get from the connection.
+  totalCount: Int
+
+  # A list of edges which contains the \`EdgeCase\` and cursor to aid in pagination.
+  edges: [EdgeCasesEdge]
+
+  # A list of \`EdgeCase\` objects.
+  nodes: [EdgeCase!]
+}
+
+# A \`EdgeCase\` edge in the connection.
+type EdgeCasesEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`EdgeCase\` at the end of the edge.
+  node: EdgeCase!
+}
+
+# Methods to use when ordering \`EdgeCase\`.
+enum EdgeCasesOrderBy {
+  NATURAL
+  NOT_NULL_HAS_DEFAULT_ASC
+  NOT_NULL_HAS_DEFAULT_DESC
+  WONT_CAST_EASY_ASC
+  WONT_CAST_EASY_DESC
+  ROW_ID_ASC
+  ROW_ID_DESC
+}
+
+scalar Email
+
+# The value at one end of a range. A range can either include this value, or not.
+input FloatRangeBoundInput {
+  # The value at one end of our range.
+  value: Float!
+
+  # Whether or not the value of this bound is included in the range.
+  inclusive: Boolean!
+}
+
+# range of numerics
+input FloatRangeInput {
+  # The starting bound of our range.
+  start: FloatRangeBoundInput
+
+  # The ending bound of our range.
+  end: FloatRangeBoundInput
+}
+
+# All input for the \`intSetMutation\` mutation.
+input IntSetMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  x: Int
+  y: Int
+  z: Int
+}
+
+# The output of our \`intSetMutation\` mutation.
+type IntSetMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integers: [Int]
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# A connection to a list of \`Int\` values.
+type IntSetQueryConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`Int\` you could get from the connection.
+  totalCount: Int
+
+  # A list of edges which contains the \`Int\` and cursor to aid in pagination.
+  edges: [IntSetQueryEdge]
+
+  # A list of \`Int\` objects.
+  nodes: [Int]
+}
+
+# A \`Int\` edge in the connection.
+type IntSetQueryEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Int\` at the end of the edge.
+  node: Int
+}
+
+# Methods to use when ordering \`Int\`.
+enum IntSetQueryOrderBy {
+  NATURAL
+}
+
+# A JavaScript object encoded in the JSON format as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+scalar Json
+
+# All input for the \`jsonIdentityMutation\` mutation.
+input JsonIdentityMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  json: Json
+}
+
+# The output of our \`jsonIdentityMutation\` mutation.
+type JsonIdentityMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  json: Json
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# The root mutation type which contains root level fields which mutate data.
+type Mutation {
+  intSetMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: IntSetMutationInput!
+  ): IntSetMutationPayload
+  jsonIdentityMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: JsonIdentityMutationInput!
+  ): JsonIdentityMutationPayload
+  noArgsMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: NoArgsMutationInput!
+  ): NoArgsMutationPayload
+  tableMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: TableMutationInput!
+  ): TableMutationPayload
+  tableSetMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: TableSetMutationInput!
+  ): TableSetMutationPayload
+  typesMutation(
+    # The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    input: TypesMutationInput!
+  ): TypesMutationPayload
+}
+
+# All input for the \`noArgsMutation\` mutation.
+input NoArgsMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`noArgsMutation\` mutation.
+type NoArgsMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  integer: Int
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# An object with a globally unique \`ID\`.
+interface Node {
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  __id: ID!
+}
+
+# Information about pagination in a connection.
+type PageInfo {
+  # When paginating forwards, are there more items?
+  hasNextPage: Boolean!
+
+  # When paginating backwards, are there more items?
+  hasPreviousPage: Boolean!
+
+  # When paginating backwards, the cursor to continue.
+  startCursor: Cursor
+
+  # When paginating forwards, the cursor to continue.
+  endCursor: Cursor
+}
+
+# A connection to a list of \`Person\` values.
+type PeopleConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`Person\` you could get from the connection.
+  totalCount: Int
+
+  # A list of edges which contains the \`Person\` and cursor to aid in pagination.
+  edges: [PeopleEdge]
+
+  # A list of \`Person\` objects.
+  nodes: [Person!]
+}
+
+# A \`Person\` edge in the connection.
+type PeopleEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Person\` at the end of the edge.
+  node: Person!
+}
+
+# Methods to use when ordering \`Person\`.
+enum PeopleOrderBy {
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  NATURAL
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  ABOUT_ASC
+  ABOUT_DESC
+  EMAIL_ASC
+  EMAIL_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+}
+
+# Person test comment
+type Person implements Node {
+  # A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  __id: ID!
+  id: Int!
+
+  # The person’s name
+  name: String!
+  about: String
+  email: Email!
+  createdAt: Datetime
+  firstName: String
+
+  # Reads and enables paginatation through a set of \`Person\`.
+  friends(
+    # The method to use when ordering \`Person\`.
+    orderBy: PersonFriendsOrderBy = NATURAL
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+  ): PersonFriendsConnection
+
+  # Reads and enables paginatation through a set of \`CompoundKey\`.
+  compoundKeysByPersonId1(
+    # The method to use when ordering \`CompoundKey\`.
+    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+  ): CompoundKeysConnection
+
+  # Reads and enables paginatation through a set of \`CompoundKey\`.
+  compoundKeysByPersonId2(
+    # The method to use when ordering \`CompoundKey\`.
+    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+  ): CompoundKeysConnection
+}
+
+# A condition to be used against \`Person\` object types. All fields are tested for equality and combined with a logical ‘and.’
+input PersonCondition {
+  # Checks for equality with the object’s \`id\` field.
+  id: Int
+
+  # Checks for equality with the object’s \`name\` field.
+  name: String
+
+  # Checks for equality with the object’s \`about\` field.
+  about: String
+
+  # Checks for equality with the object’s \`email\` field.
+  email: Email
+
+  # Checks for equality with the object’s \`createdAt\` field.
+  createdAt: Datetime
+}
+
+# A connection to a list of \`Person\` values.
+type PersonFriendsConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`Person\` you could get from the connection.
+  totalCount: Int
+
+  # A list of edges which contains the \`Person\` and cursor to aid in pagination.
+  edges: [PersonFriendsEdge]
+
+  # A list of \`Person\` objects.
+  nodes: [Person]
+}
+
+# A \`Person\` edge in the connection.
+type PersonFriendsEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Person\` at the end of the edge.
+  node: Person
+}
+
+# Methods to use when ordering \`Person\`.
+enum PersonFriendsOrderBy {
+  NATURAL
+}
+
+type Post {
+  id: Int!
+  headline: String!
+  body: String
+  authorId: Int
+}
+
+# The root query type which gives access points into the data universe.
+type Query implements Node {
+  # Fetches an object given its globally unique \`ID\`.
+  node(
+    # The globally unique \`ID\`.
+    __id: ID!
+  ): Node
+
+  # Reads and enables paginatation through a set of \`Int\`.
+  intSetQuery(
+    # The method to use when ordering \`Int\`.
+    orderBy: IntSetQueryOrderBy = NATURAL
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+    x: Int
+    y: Int
+    z: Int
+  ): IntSetQueryConnection
+  jsonIdentity(json: Json): Json
+  noArgsQuery: Int
+  tableQuery(id: Int): Post
+
+  # Reads and enables paginatation through a set of \`Person\`.
+  tableSetQuery(
+    # The method to use when ordering \`Person\`.
+    orderBy: TableSetQueryOrderBy = NATURAL
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+  ): TableSetQueryConnection
+  typesQuery(a: Int!, b: Boolean!, c: String!, d: [Int]!, e: Json!, f: FloatRangeInput!): Boolean
+
+  # Reads and enables paginatation through a set of \`CompoundKey\`.
+  allCompoundKeys(
+    # The method to use when ordering \`CompoundKey\`.
+    orderBy: CompoundKeysOrderBy = PRIMARY_KEY_ASC
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: CompoundKeyCondition
+  ): CompoundKeysConnection
+
+  # Reads a single \`CompoundKey\` using its globally unique \`ID\`.
+  compoundKey(
+    # The globally unique \`ID\` to be used in selecting a single \`CompoundKey\`.
+    __id: ID!
+  ): CompoundKey
+  compoundKeyByPersonId1AndPersonId2(personId1: Int!, personId2: Int!): CompoundKey
+
+  # Reads and enables paginatation through a set of \`EdgeCase\`.
+  allEdgeCases(
+    # The method to use when ordering \`EdgeCase\`.
+    orderBy: EdgeCasesOrderBy = NATURAL
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: EdgeCaseCondition
+  ): EdgeCasesConnection
+
+  # Reads and enables paginatation through a set of \`Person\`.
+  allPeople(
+    # The method to use when ordering \`Person\`.
+    orderBy: PeopleOrderBy = PRIMARY_KEY_ASC
+
+    # Read all values in the set before (above) this cursor.
+    before: Cursor
+
+    # Read all values in the set after (below) this cursor.
+    after: Cursor
+
+    # Only read the first \`n\` values of the set.
+    first: Int
+
+    # Only read the last \`n\` values of the set.
+    last: Int
+
+    # Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    # based pagination. May not be used with \`last\`.
+    offset: Int
+
+    # A condition to be used in determining which values should be returned by the collection.
+    condition: PersonCondition
+  ): PeopleConnection
+
+  # Reads a single \`Person\` using its globally unique \`ID\`.
+  person(
+    # The globally unique \`ID\` to be used in selecting a single \`Person\`.
+    __id: ID!
+  ): Person
+  personByEmail(email: Email!): Person
+  personById(id: Int!): Person
+
+  # Exposes the root query type nested one level down. This is helpful for Relay 1
+  # which can only query top level fields if they are in a particular form.
+  query: Query!
+
+  # The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  __id: ID!
+}
+
+# All input for the \`tableMutation\` mutation.
+input TableMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  id: Int
+}
+
+# The output of our \`tableMutation\` mutation.
+type TableMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  post: Post
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# All input for the \`tableSetMutation\` mutation.
+input TableSetMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+}
+
+# The output of our \`tableSetMutation\` mutation.
+type TableSetMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  people: [Person]
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
+
+# A connection to a list of \`Person\` values.
+type TableSetQueryConnection {
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+
+  # The count of *all* \`Person\` you could get from the connection.
+  totalCount: Int
+
+  # A list of edges which contains the \`Person\` and cursor to aid in pagination.
+  edges: [TableSetQueryEdge]
+
+  # A list of \`Person\` objects.
+  nodes: [Person]
+}
+
+# A \`Person\` edge in the connection.
+type TableSetQueryEdge {
+  # A cursor for use in pagination.
+  cursor: Cursor
+
+  # The \`Person\` at the end of the edge.
+  node: Person
+}
+
+# Methods to use when ordering \`Person\`.
+enum TableSetQueryOrderBy {
+  NATURAL
+}
+
+# All input for the \`typesMutation\` mutation.
+input TypesMutationInput {
+  # An arbitrary string value with no semantic meaning. Will be included in the
+  # payload verbatim. May be used to track mutations by the client.
+  clientMutationId: String
+  a: Int!
+  b: Boolean!
+  c: String!
+  d: [Int]!
+  e: Json!
+  f: FloatRangeInput!
+}
+
+# The output of our \`typesMutation\` mutation.
+type TypesMutationPayload {
+  # The exact same \`clientMutationId\` that was provided in the mutation input,
+  # unchanged and unused. May be used by a client to track mutations.
+  clientMutationId: String
+  boolean: Boolean
+
+  # Our root query field type. Allows us to run any query from our mutation payload.
+  query: Query
+}
 "
 `;

--- a/src/postgraphql/__tests__/postgraphqlIntegrationSchema-test.js
+++ b/src/postgraphql/__tests__/postgraphqlIntegrationSchema-test.js
@@ -23,3 +23,9 @@ test('prints a schema with a JWT generating mutation', withPgClient(async pgClie
   const gqlSchema = await createPostGraphQLSchema(pgClient, 'b', { jwtSecret: 'secret', jwtPgTypeIdentifier: 'b.jwt_token' })
   expect(printSchema(gqlSchema)).toMatchSnapshot()
 }))
+
+
+test('prints a schema without default mutations', withPgClient(async pgClient => {
+  const gqlSchema = await createPostGraphQLSchema(pgClient, 'c', { disableDefaultMutations: true })
+  expect(printSchema(gqlSchema)).toMatchSnapshot()
+}))

--- a/src/postgraphql/cli.ts
+++ b/src/postgraphql/cli.ts
@@ -36,6 +36,7 @@ program
   .option('-o, --cors', 'enable generous CORS settings. this is disabled by default, if possible use a proxy instead')
   .option('-a, --classic-ids', 'use classic global id field name. required to support Relay 1')
   .option('-j, --dynamic-json', 'enable dynamic JSON in GraphQL inputs and outputs. uses stringified JSON by default')
+  .option('-M, --disable-default-mutations', 'disable default mutations, mutation will only be possibly through Postgres functions')
   .option('--show-error-stack [setting]', 'show JavaScript error stacks in the GraphQL result errors')
 
 program.on('--help', () => console.log(`
@@ -68,6 +69,7 @@ const {
   cors: enableCors = false,
   classicIds = false,
   dynamicJson = false,
+  disableDefaultMutations = false,
   showErrorStack,
 // tslint:disable-next-line no-any
 } = program as any
@@ -98,6 +100,7 @@ const pgConfig = Object.assign(
 const server = createServer(postgraphql(pgConfig, schemas, {
   classicIds,
   dynamicJson,
+  disableDefaultMutations,
   graphqlRoute,
   graphiqlRoute,
   graphiql: !disableGraphiql,

--- a/src/postgraphql/cli.ts
+++ b/src/postgraphql/cli.ts
@@ -36,7 +36,7 @@ program
   .option('-o, --cors', 'enable generous CORS settings. this is disabled by default, if possible use a proxy instead')
   .option('-a, --classic-ids', 'use classic global id field name. required to support Relay 1')
   .option('-j, --dynamic-json', 'enable dynamic JSON in GraphQL inputs and outputs. uses stringified JSON by default')
-  .option('-M, --disable-default-mutations', 'disable default mutations, mutation will only be possibly through Postgres functions')
+  .option('-M, --disable-default-mutations', 'disable default mutations, mutation will only be possible through Postgres functions')
   .option('--show-error-stack [setting]', 'show JavaScript error stacks in the GraphQL result errors')
 
 program.on('--help', () => console.log(`

--- a/src/postgraphql/postgraphql.ts
+++ b/src/postgraphql/postgraphql.ts
@@ -26,6 +26,7 @@ export default function postgraphql (
     watchPg?: boolean,
     showErrorStack?: boolean,
     disableQueryLog?: boolean,
+    disableDefaultMutations?: boolean,
     enableCors?: boolean,
   } = {},
 ): HttpRequestHandler {

--- a/src/postgraphql/schema/createPostGraphQLSchema.ts
+++ b/src/postgraphql/schema/createPostGraphQLSchema.ts
@@ -24,6 +24,7 @@ export default async function createPostGraphQLSchema (
     dynamicJson?: boolean,
     jwtSecret?: string,
     jwtPgTypeIdentifier?: string,
+    disableDefaultMutations?: boolean,
   } = {},
 ): Promise<GraphQLSchema> {
   // If our argument was not an array, make it one.
@@ -100,6 +101,7 @@ export default async function createPostGraphQLSchema (
   const gqlSchema = createGraphQLSchema(inventory, {
     nodeIdFieldName: options.classicIds ? 'id' : '__id',
     dynamicJson: options.dynamicJson,
+    disableDefaultMutations: options.disableDefaultMutations,
 
     // If we have a JWT Postgres type, let us override the GraphQL output type
     // with our own.


### PR DESCRIPTION
This introduces a new CLI flag & option: --disable-default-mutations

When default mutations are disabled, the only mutation operations available
will be those exposed by user defined functions.