### PR TITLE
fix(graphql): fix mutation query field returning null

### DIFF
--- a/src/graphql/schema/__tests__/createMutationGqlField-test.js
+++ b/src/graphql/schema/__tests__/createMutationGqlField-test.js
@@ -1,7 +1,7 @@
 jest.mock('../getQueryGqlType')
 
 import { GraphQLNonNull, GraphQLString, GraphQLObjectType, GraphQLInputObjectType } from 'graphql'
-import getQueryGqlType from '../getQueryGqlType'
+import getQueryGqlType, { $$isQuery } from '../getQueryGqlType'
 import createMutationGqlField from '../createMutationGqlField'
 
 // Create a new object where `GraphQLString` is the prototype. This means it
@@ -58,7 +58,7 @@ test('will always include `clientMutationId` and `query` fields', () => {
   expect(field.type.getFields().clientMutationId.type).toBe(GraphQLString)
   expect(field.type.getFields().clientMutationId.resolve({ clientMutationId })).toBe(clientMutationId)
   expect(field.type.getFields().query.type).toBe(queryType)
-  expect(field.type.getFields().query.resolve()).toBe(null)
+  expect(field.type.getFields().query.resolve()).toBe($$isQuery)
   expect(getQueryGqlType.mock.calls).toEqual([[buildToken]])
 })
 

--- a/src/graphql/schema/createMutationPayloadGqlType.ts
+++ b/src/graphql/schema/createMutationPayloadGqlType.ts
@@ -2,7 +2,7 @@ import { GraphQLString, GraphQLObjectType, GraphQLFieldConfig } from 'graphql'
 import { formatName, buildObject } from '../utils'
 import BuildToken from './BuildToken'
 import { MutationValue } from './createMutationGqlField'
-import getQueryGqlType from './getQueryGqlType'
+import getQueryGqlType, { $$isQuery } from './getQueryGqlType'
 
 /**
  * Creates the payload type for a GraphQL mutation. Uses the provided output
@@ -55,7 +55,7 @@ export default function createMutationPayloadGqlType <T>(
         ['query', {
           description: 'Our root query field type. Allows us to run any query from our mutation payload.',
           type: getQueryGqlType(buildToken),
-          resolve: () => null,
+          resolve: () => $$isQuery,
         }],
       ],
     ),

--- a/src/postgraphql/__tests__/__snapshots__/postgraphqlIntegrationOperations-test.js.snap
+++ b/src/postgraphql/__tests__/__snapshots__/postgraphqlIntegrationOperations-test.js.snap
@@ -604,6 +604,9 @@ Object {
   "data": Object {
     "a": Object {
       "clientMutationId": null,
+      "query": Object {
+        "__id": "query",
+      },
       "type": Object {
         "__id": "WyJ0eXBlcyIsMjAxXQ==",
         "anIntRange": Object {
@@ -749,6 +752,9 @@ Object {
         "id": 9000,
         "name": "John Smith Jr.",
       },
+      "query": Object {
+        "__id": "query",
+      },
     },
     "c": Object {
       "a": Object {
@@ -808,6 +814,9 @@ Object {
         "id": 20,
         "name": "Best Pal",
       },
+      "query": Object {
+        "__id": "query",
+      },
     },
     "d": Object {
       "clientMutationId": "world",
@@ -833,15 +842,24 @@ Object {
         "__id": "WyJwZW9wbGUiLDIwXQ==",
         "name": "Best Pal",
       },
+      "query": Object {
+        "__id": "query",
+      },
     },
     "e": Object {
       "edgeCase": Object {
         "notNullHasDefault": true,
       },
+      "query": Object {
+        "__id": "query",
+      },
     },
     "f": Object {
       "edgeCase": Object {
         "notNullHasDefault": false,
+      },
+      "query": Object {
+        "__id": "query",
       },
     },
   },
@@ -860,6 +878,9 @@ Object {
         "headline": "No… It’s a thing; it’s like a plan, but with more greatness.",
         "id": 1,
       },
+      "query": Object {
+        "__id": "query",
+      },
     },
     "b": Object {
       "clientMutationId": "hello",
@@ -869,6 +890,9 @@ Object {
         "authorId": 1,
         "headline": "I hate yogurt. It’s just stuff with bits in.",
         "id": 2,
+      },
+      "query": Object {
+        "__id": "query",
       },
     },
     "c": null,
@@ -881,6 +905,9 @@ Object {
         "headline": "Is that a cooking show?",
         "id": 3,
       },
+      "query": Object {
+        "__id": "query",
+      },
     },
     "e": Object {
       "clientMutationId": null,
@@ -890,6 +917,9 @@ Object {
         "authorId": 3,
         "headline": "Stop talking, brain thinking. Hush.",
         "id": 6,
+      },
+      "query": Object {
+        "__id": "query",
       },
     },
     "f": Object {
@@ -901,6 +931,9 @@ Object {
         "headline": "You know how I sometimes have really brilliant ideas?",
         "id": 9,
       },
+      "query": Object {
+        "__id": "query",
+      },
     },
     "g": null,
     "h": Object {
@@ -911,6 +944,9 @@ Object {
         "authorId": 3,
         "headline": "They’re not aliens, they’re Earth…liens!",
         "id": 11,
+      },
+      "query": Object {
+        "__id": "query",
       },
     },
     "i": Object {
@@ -929,6 +965,9 @@ Object {
         "personId2": 3,
       },
       "deletedCompoundKeyId": "WyJjb21wb3VuZF9rZXlzIiw0LDNd",
+      "query": Object {
+        "__id": "query",
+      },
     },
     "j": Object {
       "clientMutationId": null,
@@ -946,6 +985,9 @@ Object {
         "personId2": 3,
       },
       "deletedCompoundKeyId": "WyJjb21wb3VuZF9rZXlzIiwyLDNd",
+      "query": Object {
+        "__id": "query",
+      },
     },
     "k": Object {
       "clientMutationId": null,
@@ -955,6 +997,9 @@ Object {
         "email": "budd.deey@email.com",
         "id": 3,
         "name": "Budd Deey",
+      },
+      "query": Object {
+        "__id": "query",
       },
     },
   },
@@ -977,6 +1022,9 @@ Object {
         "id": 1,
         "name": "John Smith Sr.",
       },
+      "query": Object {
+        "__id": "query",
+      },
     },
     "b": Object {
       "clientMutationId": "hello",
@@ -986,6 +1034,9 @@ Object {
         "email": "sarah.smith@email.com",
         "id": 2,
         "name": "Sarah Smith",
+      },
+      "query": Object {
+        "__id": "query",
       },
     },
     "c": Object {
@@ -997,6 +1048,9 @@ Object {
         "id": 2,
         "name": "Sarah Smith",
       },
+      "query": Object {
+        "__id": "query",
+      },
     },
     "d": Object {
       "clientMutationId": null,
@@ -1007,6 +1061,9 @@ Object {
         "id": 3,
         "name": "Best Pal",
       },
+      "query": Object {
+        "__id": "query",
+      },
     },
     "e": Object {
       "clientMutationId": null,
@@ -1016,6 +1073,9 @@ Object {
         "email": "kathryn.ramirez@email.com",
         "id": 4,
         "name": "Kathryn Ramirez",
+      },
+      "query": Object {
+        "__id": "query",
       },
     },
     "f": Object {
@@ -1034,6 +1094,9 @@ Object {
         "personId1": 2,
         "personId2": 2,
       },
+      "query": Object {
+        "__id": "query",
+      },
     },
     "g": Object {
       "clientMutationId": "hello",
@@ -1051,6 +1114,9 @@ Object {
         "personId1": 3,
         "personId2": 2,
       },
+      "query": Object {
+        "__id": "query",
+      },
     },
     "h": Object {
       "clientMutationId": "world",
@@ -1067,6 +1133,9 @@ Object {
         },
         "personId1": 4,
         "personId2": 3,
+      },
+      "query": Object {
+        "__id": "query",
       },
     },
   },

--- a/src/postgraphql/__tests__/fixtures/queries/mutation-create.graphql
+++ b/src/postgraphql/__tests__/fixtures/queries/mutation-create.graphql
@@ -102,6 +102,7 @@ mutation {
         bazBuz
       }
     }
+    query { __id }
   }
   b: createPerson(input: {
     person: {
@@ -151,6 +152,7 @@ mutation {
       __id
       name
     }
+    query { __id }
   }
   e: createEdgeCase(input: {
     edgeCase: {
@@ -160,6 +162,7 @@ mutation {
     edgeCase {
       notNullHasDefault
     }
+    query { __id }
   }
   f: createEdgeCase(input: {
     edgeCase: {}
@@ -167,6 +170,7 @@ mutation {
     edgeCase {
       notNullHasDefault
     }
+    query { __id }
   }
 }
 
@@ -186,6 +190,7 @@ fragment createPersonPayload on CreatePersonPayload {
   e: personEdge(orderBy: EMAIL_ASC) { ...peopleEdge }
   f: personEdge(orderBy: EMAIL_DESC) { ...peopleEdge }
   g: personEdge(orderBy: NATURAL) { ...peopleEdge }
+  query { __id }
 }
 
 fragment peopleEdge on PeopleEdge {

--- a/src/postgraphql/__tests__/fixtures/queries/mutation-delete.graphql
+++ b/src/postgraphql/__tests__/fixtures/queries/mutation-delete.graphql
@@ -21,6 +21,7 @@ fragment deletePostPayload on DeletePostPayload {
     headline
     authorId
   }
+  query { __id }
 }
 
 fragment deleteCompoundKeyPayload on DeleteCompoundKeyPayload {
@@ -39,6 +40,7 @@ fragment deleteCompoundKeyPayload on DeleteCompoundKeyPayload {
       name
     }
   }
+  query { __id }
 }
 
 fragment deletePersonPayload on DeletePersonPayload {
@@ -50,4 +52,5 @@ fragment deletePersonPayload on DeletePersonPayload {
     name
     email
   }
+  query { __id }
 }

--- a/src/postgraphql/__tests__/fixtures/queries/mutation-update.graphql
+++ b/src/postgraphql/__tests__/fixtures/queries/mutation-update.graphql
@@ -69,6 +69,7 @@ fragment updatePersonPayload on UpdatePersonPayload {
     email
     about
   }
+  query { __id }
 }
 
 fragment updateCompoundKeyPayload on UpdateCompoundKeyPayload {
@@ -87,4 +88,5 @@ fragment updateCompoundKeyPayload on UpdateCompoundKeyPayload {
       name
     }
   }
+  query { __id }
 }


### PR DESCRIPTION
Fixes https://github.com/calebmer/postgraphql/issues/188

In order to support selecting `Query` from `node` for Relay 1, the value of `Query` was required to be a symbol named `$$isQuery`. This wasn’t always the case, originally any value for the query was acceptable so mutations would just return `null` instead of the query value. This fixes that.

/cc @benjie