### PR TITLE
Help contributors get started

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,3 +15,62 @@ PostGraphQL uses Travis CI to test builds and enforce lint rules:
 The codebase is documented via READMEs throughout the src folder heirarchy,
 starting with [src/README.md](src/README.md). Contributions are also encouraged
 where these files are missing or inadequate.
+
+Commit messages
+---------------
+
+PostGraphQL team use [karma-style][] commit messages: a type
+(feat/fix/chore/docs/etc), a scope (graphql/postgraphql/examples/tests) and
+then the commit message. Commit messages are written in the imperative tense.
+
+Here's a few examples:
+
+```
+feat(ci): run against multiple postgres versions
+fix(postgraphql): fix opaque error messages
+chore(docs): rename anonymous role to default role
+```
+
+Types:
+
+- chore
+- docs
+- feat
+- fix
+- refactor
+- style
+- test
+
+Scopes:
+
+- *
+- catalog
+- ci
+- collection
+- connection
+- contributing
+- docs
+- examples
+- forumCatalog
+- gitignore
+- graphql
+- interface
+- library
+- main
+- package
+- paginator
+- postgraphql
+- postgres
+- procedures
+- readme
+- resolve
+- scripts
+- server
+- tests
+- typings
+- typings
+- vscode
+
+New scopes can be added as necessary, when doing so please add them to this list.
+
+[karma-style]: http://karma-runner.github.io/1.0/dev/git-commit-msg.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+Contributing
+============
+
+Pull requests to PostGraphQL are welcome. To get started:
+
+```
+createdb postgraphql_test
+npm run build
+npm test
+```
+
+The codebase is documented via READMEs throughout the src folder heirarchy,
+starting with [src/README.md](src/README.md). Contributions are also encouraged
+where these files are missing or inadequate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,9 @@ npm run build
 npm test
 ```
 
+PostGraphQL uses Travis CI to test builds and enforce lint rules:
+[travis-ci.org/calebmer/postgraphql](https://travis-ci.org/calebmer/postgraphql).
+
 The codebase is documented via READMEs throughout the src folder heirarchy,
 starting with [src/README.md](src/README.md). Contributions are also encouraged
 where these files are missing or inadequate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,29 +1,57 @@
-Contributing
-============
+# Contributing
+The PostGraphQL project welcomes all contributors, we want to invest in you so you can invest back into PostGraphQL. Together we can make great software that enables developers to build powerful applications in much less time then would previously be taken. This document aims to help you get started contributing to the project.
 
-Pull requests to PostGraphQL are welcome. To get started:
+As PostGraphQL may be a piece of critical infrastructure in your app, it is only fair to run the project as [OPEN Open Source](http://openopensource.org/). If contribute meaningful work to the PostGraphQL project you will be made a collaborator which allows you to create new branches and approve pull requests.
 
+The codebase is documented via READMEs throughout the src folder heirarchy, starting with [`src/README.md`](src/README.md). Contributions are also encouraged where these files are missing or inadequate.
+
+To get started hacking on the codebase, make sure Postgres is listening on `localhost:5432` and then run:
+
+```bash
+scripts/run-kitchen-sink-schema
+scripts/dev
 ```
+
+The first script will add the kitchen sink SQL schemas (named `a`, `b`, and `c`) to your Postgres database at `localhost:5432`. The second script will start PostGraphQL in watch mode and open GraphiQL in your default browser. Whenever you change the PostGraphQL source code, the `scripts/dev` command will restart the PostGraphQL server, just remember to refresh GraphiQL. To manually restart the server type in `rs` and hit enter while `scripts/dev` is running. To start PostGraphQL with arguments besides the defaults, just add them to `scripts/dev` like so:
+
+```bash
+scripts/dev --schema forum_example --secret keyboard_kitten
+```
+
+## Tests
+PostGraphQL uses [Jest](http://facebook.github.io/jest/) for testing to take advantage of Jest’s snapshot feature. To run PostGraphQL tests you will need to first create the `postgraphql_test` database in your Postgres instance running on `localhost:5432`. To do so run the following:
+
+```bash
 createdb postgraphql_test
-npm run build
-npm test
 ```
 
-PostGraphQL uses Travis CI to test builds and enforce lint rules:
+To run the full test suite run:
+
+```bash
+scripts/test
+```
+
+When developing PostGraphQL, we recommend using the Jest watch mode feature. So instead you would run tests like so:
+
+```bash
+scripts/test --watch
+```
+
+Now, only the tests in the files you have changed will be run. There are some slow tests in the PostGraphQL suite so hopefully this should make your development time faster. Once you are in watch mode, Jest will present you with some options you can use to better configure your testing experience.
+
+### Snapshots
+PostGraphQL makes use of the Jest snapshot feature. Even when you change small things in PostGraphQL the snapshot tests are likely to fail. This is OK, the snapshot tests are expected to fail. To make the snapshot tests pass again, run `scripts/test --watch` and then press `u` once the initial tests have run. Or run `scripts/test --updateSnapshot`. This will rerun the tests and changing the snapshot files in the repository. Commit the changes to the snapshots and the changed snapshots will be reviewed along with the rest of your changes in the PR review process.
+
+### Linting
+PostGraphQL uses [TSLint](http://palantir.github.io/tslint/) and Travis CI to test builds and enforce lint rules:
 [travis-ci.org/calebmer/postgraphql](https://travis-ci.org/calebmer/postgraphql).
 
-The codebase is documented via READMEs throughout the src folder heirarchy,
-starting with [src/README.md](src/README.md). Contributions are also encouraged
-where these files are missing or inadequate.
-
-Commit messages
----------------
-
-PostGraphQL team use [karma-style][] commit messages: a type
-(feat/fix/chore/docs/etc), a scope (graphql/postgraphql/examples/tests) and
+## Commit messages
+PostGraphQL team use [karma-style](http://karma-runner.github.io/1.0/dev/git-commit-msg.html) commit messages: a type
+(`feat`/`fix`/`chore`/`doc`/etc.), a scope (`graphql`/`postgraphql`/`examples`/`tests`) and
 then the commit message. Commit messages are written in the imperative tense.
 
-Here's a few examples:
+Here’s a few examples:
 
 ```
 feat(ci): run against multiple postgres versions
@@ -31,46 +59,26 @@ fix(postgraphql): fix opaque error messages
 chore(docs): rename anonymous role to default role
 ```
 
-Types:
+When comitting to a branch or a PR you do not need to adhere to this format. However, all commits to the `master` branch *must* be in this format. Often all of the commits in a PR will be squashed and a commit message of this format will be written to summarize the changes.
 
-- chore
-- docs
-- feat
-- fix
-- refactor
-- style
-- test
+You must use one of the following types:
 
-Scopes:
+- `chore`
+- `docs`
+- `feat`
+- `fix`
+- `refactor`
+- `style`
+- `test`
 
-- *
-- catalog
-- ci
-- collection
-- connection
-- contributing
-- docs
-- examples
-- forumCatalog
-- gitignore
-- graphql
-- interface
-- library
-- main
-- package
-- paginator
-- postgraphql
-- postgres
-- procedures
-- readme
-- resolve
-- scripts
-- server
-- tests
-- typings
-- typings
-- vscode
+Common scopes are as follows. You are not required to use any of the following scopes and may instead invent your own. These are just a few that get commonly used.
 
-New scopes can be added as necessary, when doing so please add them to this list.
-
-[karma-style]: http://karma-runner.github.io/1.0/dev/git-commit-msg.html
+- `*`
+- `postgraphql`
+- `graphql`
+- `interface`
+- `postgres`
+- `package`
+- `scripts`
+- `examples`
+- `ci`

--- a/package.json
+++ b/package.json
@@ -25,7 +25,12 @@
   "bin": {
     "postgraphql": "build/postgraphql/cli.js"
   },
-  "scripts": {},
+  "scripts": {
+    "build": "./scripts/build",
+    "dev": "./scripts/dev",
+    "lint": "./scripts/lint",
+    "test": "./scripts/test"
+  },
   "dependencies": {
     "body-parser": "^1.15.2",
     "chalk": "1.1.3",

--- a/src/postgraphql/__tests__/postgraphqlIntegrationOperations-test.js
+++ b/src/postgraphql/__tests__/postgraphqlIntegrationOperations-test.js
@@ -5,9 +5,8 @@ import withPgClient from '../../postgres/__tests__/fixtures/withPgClient'
 import { $$pgClient } from '../../postgres/inventory/pgClientFromContext'
 import createPostGraphQLSchema from '../schema/createPostGraphQLSchema'
 
-// This test suite can be flaky in CI. Increase it’s timeout.
-if (process.env.CI)
-  jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 10
+// This test suite can be flaky. Increase it’s timeout.
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 20
 
 const kitchenSinkData = new Promise((resolve, reject) => {
   readFile('examples/kitchen-sink/data.sql', (error, data) => {

--- a/src/postgraphql/__tests__/postgraphqlIntegrationSchema-test.js
+++ b/src/postgraphql/__tests__/postgraphqlIntegrationSchema-test.js
@@ -5,9 +5,8 @@ import { printSchema } from 'graphql'
 import withPgClient from '../../postgres/__tests__/fixtures/withPgClient'
 import createPostGraphQLSchema from '../schema/createPostGraphQLSchema'
 
-// This test suite can be flaky in CI. Increase it’s timeout.
-if (process.env.CI)
-  jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 10
+// This test suite can be flaky. Increase it’s timeout.
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 20
 
 test('prints a schema with the default options', withPgClient(async pgClient => {
   const gqlSchema = await createPostGraphQLSchema(pgClient, ['a', 'b', 'c'])

--- a/src/postgres/introspection/__tests__/introspectDatabase-test.js
+++ b/src/postgres/introspection/__tests__/introspectDatabase-test.js
@@ -2,9 +2,8 @@ import withPgClient from '../../__tests__/fixtures/withPgClient'
 import createKitchenSinkPgSchema from '../../__tests__/fixtures/createKitchenSinkPgSchema'
 import introspectDatabase from '../introspectDatabase'
 
-// This test suite can be flaky in CI. Increase it’s timeout.
-if (process.env.CI)
-  jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 10
+// This test suite can be flaky. Increase it’s timeout.
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 20
 
 /**
  * Gets a local identifier that is independent of the object id assigned by

--- a/src/postgres/inventory/collection/__tests__/PgCollection-test.js
+++ b/src/postgres/inventory/collection/__tests__/PgCollection-test.js
@@ -8,9 +8,8 @@ import { PgCatalog, introspectDatabase } from '../../../introspection'
 import { $$pgClient } from '../../pgClientFromContext'
 import PgCollection from '../PgCollection'
 
-// This test suite can be flaky in CI. Increase it’s timeout.
-if (process.env.CI)
-  jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 10
+// This test suite can be flaky. Increase it’s timeout.
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 20
 
 /**
  * @type {PgCatalog}

--- a/src/postgres/inventory/collection/__tests__/PgCollectionKey-test.js
+++ b/src/postgres/inventory/collection/__tests__/PgCollectionKey-test.js
@@ -5,9 +5,8 @@ import { $$pgClient } from '../../pgClientFromContext.ts'
 import PgCollection from '../PgCollection'
 import PgCollectionKey from '../PgCollectionKey'
 
-// This test suite can be flaky in CI. Increase it’s timeout.
-if (process.env.CI)
-  jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 10
+// This test suite can be flaky. Increase it’s timeout.
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000 * 20
 
 /**
  * @type {PgCollectionKey}


### PR DESCRIPTION
It seems that CI isn't the only place that has troubles running the tests without timeouts, my ancient iMac can't complete them as fast as necessary either. To that end I've removed the CI clauses and extended the timeouts to 20 seconds which now means that none of the tests timeout on my machine any more.

I've derived from the commit messages that you're using the same format as AngularJS/Karma; I found it more pleasant to link to the Karma page rather than google docs so I've linked there. I used the following command to extract the accepted types/scopes, and then filtered them down for consistency

```
git log --pretty='%s' | grep ':' | sed 's/:.*//' | sort -u
```

Since we use both doc and docs, test and tests, I have picked the one that I feel is more consistent with the upstream commit message styling (e.g. 'docs' is preferred in types, and 'tests' is preferred in scopes).

This PR replaces #186

Feedback welcome 👍 
