### PR TITLE
Server side network layer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,13 @@
-import { postgraphql, createPostGraphQLSchema } from './postgraphql'
+import {
+  postgraphql,
+  postgraphqlServerSideNetworkLayerFactory,
+  createPostGraphQLSchema
+} from './postgraphql'
 
 export default postgraphql
 
 export {
   postgraphql,
+  postgraphqlServerSideNetworkLayerFactory,
   createPostGraphQLSchema,
 }

--- a/src/postgraphql/http/ServerSideNetworkLayer.js
+++ b/src/postgraphql/http/ServerSideNetworkLayer.js
@@ -1,3 +1,13 @@
+import executeQuery from './executeQuery'
+import {
+  Source,
+  parse as parseGraphql,
+  validate as validateGraphql,
+  execute as executeGraphql,
+  getOperationAST,
+  formatError as defaultFormatError,
+  print as printGraphql,
+} from 'graphql'
 // See: https://facebook.github.io/relay/docs/interfaces-relay-network-layer.html
 //
 // This class implements a "network layer" for relay that can be used on the
@@ -16,7 +26,6 @@ export default class ServerSideNetworkLayer {
   }
 
   sendQueries(queryRequests) {
-    console.dir(queryRequests)
     return Promise.all(queryRequests.map(
       queryRequest => this._fetch(queryRequest).then(result => {
         if (result.errors) {
@@ -34,14 +43,23 @@ export default class ServerSideNetworkLayer {
 
   // Private:
 
-  _fetch(queryRequest) {
-    return new Promise((resolve, reject) => {
+  _fetch(request) {
+    return new Promise(async (resolve, reject) => {
       let result
       let pgRole
       let error
-      reject(new Error('Unimplemented'))
-      return
-      /*
+      const query = request.getQueryString()
+      const variables = request.getVariables()
+      const source = new Source(query, 'GraphQL Http Request')
+      let queryDocumentAst
+      let operationName
+      try {
+        queryDocumentAst = parseGraphql(source)
+      }
+      catch (error) {
+        reject(error)
+        return
+      }
       try {
         ;({result, pgRole} = await executeQuery(
           this.pgPool,
@@ -58,11 +76,8 @@ export default class ServerSideNetworkLayer {
       if (error) {
         reject(error);
       } else {
-        console.dir(result);
-        // result.errors, result.data
         resolve(result);
       }
-      */
     })
   }
 };

--- a/src/postgraphql/http/ServerSideNetworkLayer.js
+++ b/src/postgraphql/http/ServerSideNetworkLayer.js
@@ -1,0 +1,68 @@
+// See: https://facebook.github.io/relay/docs/interfaces-relay-network-layer.html
+//
+// This class implements a "network layer" for relay that can be used on the
+// server side, enabling server-side rendering of a relay app.
+
+export default class ServerSideNetworkLayer {
+  constructor(pgPool, gqlSchema, jwtToken, options = {}) {
+    this.pgPool = pgPool;
+    this.gqlSchema = gqlSchema;
+    this.jwtToken = jwtToken;
+    this.options = options;
+  }
+
+  sendMutation(mutationRequest) {
+    return Promise.reject('Mutations not supported on the server');
+  }
+
+  sendQueries(queryRequests) {
+    console.dir(queryRequests)
+    return Promise.all(queryRequests.map(
+      queryRequest => this._fetch(queryRequest).then(result => {
+        if (result.errors) {
+          queryRequest.reject(new Error("Query failed"));
+        } else {
+          queryRequest.resolve({response: result.data});
+        }
+      }).catch(e => queryRequest.reject(e))
+    ))
+  }
+
+  supports(...options) {
+    return false;
+  }
+
+  // Private:
+
+  _fetch(queryRequest) {
+    return new Promise((resolve, reject) => {
+      let result
+      let pgRole
+      let error
+      reject(new Error('Unimplemented'))
+      return
+      /*
+      try {
+        ;({result, pgRole} = await executeQuery(
+          this.pgPool,
+          this.options,
+          this.jwtToken,
+          this.gqlSchema,
+          queryDocumentAst,
+          variables,
+          operationName
+        ))
+      } catch (e) {
+        error = e;
+      }
+      if (error) {
+        reject(error);
+      } else {
+        console.dir(result);
+        // result.errors, result.data
+        resolve(result);
+      }
+      */
+    })
+  }
+};

--- a/src/postgraphql/http/executeQuery.js
+++ b/src/postgraphql/http/executeQuery.js
@@ -1,0 +1,56 @@
+import debugPgClient from './debugPgClient'
+import setupRequestPgClientTransaction from './setupRequestPgClientTransaction'
+import { $$pgClient } from '../../postgres/inventory/pgClientFromContext'
+import {
+  Source,
+  parse as parseGraphql,
+  validate as validateGraphql,
+  execute as executeGraphql,
+  getOperationAST,
+  formatError as defaultFormatError,
+  print as printGraphql,
+} from 'graphql'
+
+export default async function(
+  pgPool,
+  options,
+  jwtToken,
+  gqlSchema,
+  queryDocumentAst,
+  variables,
+  operationName,
+) {
+
+  // Connect a new Postgres client and start a transaction.
+  const pgClient = await pgPool.connect()
+
+  // Enhance our Postgres client with debugging stuffs.
+  debugPgClient(pgClient)
+
+  // Begin our transaction and set it up.
+  await pgClient.query('begin')
+  let pgRole = await setupRequestPgClientTransaction(jwtToken, pgClient, {
+    jwtSecret: options.jwtSecret,
+    pgDefaultRole: options.pgDefaultRole,
+  })
+
+  let result
+  try {
+    result = await executeGraphql(
+      gqlSchema,
+      queryDocumentAst,
+      null,
+      { [$$pgClient]: pgClient },
+      variables,
+      operationName,
+    )
+  }
+  // Cleanup our Postgres client by ending the transaction and releasing
+  // the client back to the pool. Always do this even if the query fails.
+  finally {
+    await pgClient.query('commit')
+    pgClient.release()
+
+  }
+  return {result, pgRole}
+}

--- a/src/postgraphql/http/setupRequestPgClientTransaction.js
+++ b/src/postgraphql/http/setupRequestPgClientTransaction.js
@@ -17,9 +17,7 @@ const jwt = require('jsonwebtoken')
 // client. If this happens it’s a huge security vulnerability. Never using the
 // keyword `return` in this function is a good first step. You can still throw
 // errors, however, as this will stop the request execution.
-export default async function setupRequestPgClientTransaction (request, pgClient, { jwtSecret, pgDefaultRole } = {}) {
-  // Get the JWT token string from our request.
-  const jwtToken = getJWTToken(request)
+export default async function setupRequestPgClientTransaction (jwtToken, pgClient, { jwtSecret, pgDefaultRole } = {}) {
 
   // If a JWT token was defined, but a secret was not procided to the server
   // throw a 403 error.
@@ -103,7 +101,7 @@ const authorizationBearerRex = /^\s*bearer\s+([a-z0-9\-._~+/]+=*)\s*$/i
  * @param {IncomingMessage} request
  * @returns {string | null}
  */
-function getJWTToken (request) {
+export function getJWTToken (request) {
   const { authorization } = request.headers
 
   // If there was no authorization header, just return null.

--- a/src/postgraphql/index.ts
+++ b/src/postgraphql/index.ts
@@ -1,7 +1,8 @@
-import postgraphql from './postgraphql'
+import postgraphql, {postgraphqlServerSideNetworkLayerFactory} from './postgraphql'
 import createPostGraphQLSchema from './schema/createPostGraphQLSchema'
 
 export {
   postgraphql,
+  postgraphqlServerSideNetworkLayerFactory,
   createPostGraphQLSchema,
 }


### PR DESCRIPTION
To enable server side rendering (aka SSR, isomorphic, universal, etc) for a relay app you'll probably want to use something like [isomorphic-relay-router](https://github.com/denvned/isomorphic-relay-router). However, if you're using postgraphql as a middleware it seems wasteful to try and do a full HTTP request to your server to achieve this, so this PR is a proof-of-concept (and abysmal code!) to create a ServerSideNetworkLayer that enables isomorphic-relay-router to run with minimal overhead.

I'm using it like this:

```js
expressApp.use((req, res, next) => {
  req.getServerSideNetworkLayer = (done) => {
    return networkLayerFactory(getJWTToken(req, res), done);
  };
  next();
});

[...]

        req.getServerSideNetworkLayer((err, networkLayer) => {
          if (err) {
            res.status(500).send(err.message);
            return;
          }
          IsomorphicRouter.prepareData(renderProps, networkLayer).then(render).catch(next);
        });
```