### PR TITLE
Fix daylight savings time failures

### DIFF
--- a/src/postgres/__tests__/fixtures/withPgClient.ts
+++ b/src/postgres/__tests__/fixtures/withPgClient.ts
@@ -20,7 +20,7 @@ export default function withPgClient (fn: (client: Client) => void | Promise<voi
       throw client
 
     await client.query('begin')
-    await client.query('set local timezone to \'-04:00\'')
+    await client.query('set local timezone to \'+04:00\'')
 
     // Run our kichen sink schema Sql, if there is an error we should report it
     try {

--- a/src/postgres/__tests__/fixtures/withPgClient.ts
+++ b/src/postgres/__tests__/fixtures/withPgClient.ts
@@ -20,7 +20,7 @@ export default function withPgClient (fn: (client: Client) => void | Promise<voi
       throw client
 
     await client.query('begin')
-    await client.query('set local timezone to \'EDT\'')
+    await client.query('set local timezone to \'-04:00\'')
 
     // Run our kichen sink schema Sql, if there is an error we should report it
     try {

--- a/src/postgres/__tests__/fixtures/withPgClient.ts
+++ b/src/postgres/__tests__/fixtures/withPgClient.ts
@@ -20,7 +20,7 @@ export default function withPgClient (fn: (client: Client) => void | Promise<voi
       throw client
 
     await client.query('begin')
-    await client.query('set local timezone to \'US/Eastern\'')
+    await client.query('set local timezone to \'EDT\'')
 
     // Run our kichen sink schema Sql, if there is an error we should report it
     try {


### PR DESCRIPTION
As @benjie mentioned in the Gitter chat, tests in this repo have probably been failing thanks to daylight savings time lol :blush:

This should fix the problem by setting our tests to run in Eastern Daylight Time instead of oscillating between Eastern Daylight Time and Eastern Standard Time, I think. Honestly, I just looked up the [Postgres timezone](https://www.postgresql.org/docs/7.2/static/timezones.html) docs and made the change through GitHub, hope this works :wink: