### PR TITLE
Add tests for create/update w/ null

### DIFF
--- a/src/postgraphql/__tests__/__snapshots__/postgraphqlIntegrationOperations-test.js.snap
+++ b/src/postgraphql/__tests__/__snapshots__/postgraphqlIntegrationOperations-test.js.snap
@@ -880,6 +880,68 @@ Object {
         "__id": "query",
       },
     },
+    "g": Object {
+      "a": Object {
+        "cursor": null,
+        "node": Object {
+          "__id": "WyJwZW9wbGUiLDE5OThd",
+          "name": "Budd Deey",
+        },
+      },
+      "b": Object {
+        "cursor": null,
+        "node": Object {
+          "__id": "WyJwZW9wbGUiLDE5OThd",
+          "name": "Budd Deey",
+        },
+      },
+      "c": Object {
+        "cursor": null,
+        "node": Object {
+          "__id": "WyJwZW9wbGUiLDE5OThd",
+          "name": "Budd Deey",
+        },
+      },
+      "clientMutationId": null,
+      "d": Object {
+        "cursor": null,
+        "node": Object {
+          "__id": "WyJwZW9wbGUiLDE5OThd",
+          "name": "Budd Deey",
+        },
+      },
+      "e": Object {
+        "cursor": null,
+        "node": Object {
+          "__id": "WyJwZW9wbGUiLDE5OThd",
+          "name": "Budd Deey",
+        },
+      },
+      "f": Object {
+        "cursor": null,
+        "node": Object {
+          "__id": "WyJwZW9wbGUiLDE5OThd",
+          "name": "Budd Deey",
+        },
+      },
+      "g": Object {
+        "cursor": null,
+        "node": Object {
+          "__id": "WyJwZW9wbGUiLDE5OThd",
+          "name": "Budd Deey",
+        },
+      },
+      "person": Object {
+        "__id": "WyJwZW9wbGUiLDE5OThd",
+        "about": null,
+        "email": "budd.deey.the.second@email.com",
+        "id": 1998,
+        "name": "Budd Deey",
+      },
+      "query": Object {
+        "__id": "query",
+      },
+    },
   },
 }
 `;
@@ -1151,6 +1213,19 @@ Object {
         },
         "personId1": 4,
         "personId2": 3,
+      },
+      "query": Object {
+        "__id": "query",
+      },
+    },
+    "i": Object {
+      "clientMutationId": null,
+      "person": Object {
+        "__id": "WyJwZW9wbGUiLDJd",
+        "about": null,
+        "email": "sarah.smith@email.com",
+        "id": 2,
+        "name": "Sarah Smith",
       },
       "query": Object {
         "__id": "query",

--- a/src/postgraphql/__tests__/fixtures/queries/mutation-create.graphql
+++ b/src/postgraphql/__tests__/fixtures/queries/mutation-create.graphql
@@ -172,6 +172,14 @@ mutation {
     }
     query { __id }
   }
+  g: createPerson(input: {
+    person: {
+      id: 1998
+      name: "Budd Deey"
+      email: "budd.deey.the.second@email.com"
+      about: null
+    }
+  }) { ...createPersonPayload }
 }
 
 fragment createPersonPayload on CreatePersonPayload {

--- a/src/postgraphql/__tests__/fixtures/queries/mutation-update.graphql
+++ b/src/postgraphql/__tests__/fixtures/queries/mutation-update.graphql
@@ -21,6 +21,12 @@ mutation {
       about: "Now with an “H.”"
     }
   }) { ...updatePersonPayload }
+  i: updatePerson(input: {
+    __id: "WyJwZW9wbGUiLDJd"
+    personPatch: {
+      about: null
+    }
+  }) { ...updatePersonPayload }
   d: updatePersonById(input: {
     id: 3
     personPatch: {


### PR DESCRIPTION
Closes https://github.com/calebmer/postgraphql/issues/108

This functionality has worked since the release of GraphQL `0.8.*` thanks to @langpavel’s work, these tests just ensure that null with creates and updates works as expected to prevent future regression.