### PR TITLE
Tweaks to GraphiQL PR

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -3,6 +3,8 @@
 set -e
 cd $(dirname $0)/..
 
+./scripts/postinstall
+
 npm_bin=$(npm bin)
 
 echo "Cleaning build"

--- a/scripts/dev
+++ b/scripts/dev
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+set -e
+cd $(dirname $0)/..
+
+./scripts/postinstall
+
 npm_bin=$(npm bin)
 
 export POSTGRAPHQL_ENV=development
@@ -15,7 +20,7 @@ $npm_bin/nodemon \
   --exec "$npm_bin/ts-node --ignore node_modules --disableWarnings src/postgraphql/cli.ts --schema a,b,c --show-error-stack json --watch $@" &
 
 # Ensure forked process is killed even if we die unexpectedly
-trap 'trap - SIGINT SIGTERM EXIT; JOBS="$(jobs -p)"; [[ "$JOBS" != "" ]] && kill $JOBS || true' SIGINT SIGTERM EXIT
+trap 'trap - SIGINT SIGTERM EXIT; JOBS="$(jobs -p)"; [[ "$JOBS" != "" ]] && kill $JOBS 2>/dev/null || true' SIGINT SIGTERM EXIT
 
 # Run `react-scripts` in the GraphiQL directory as well parallel, but pipe the
 # output to `/dev/null`.

--- a/scripts/dev
+++ b/scripts/dev
@@ -24,6 +24,6 @@ trap 'trap - SIGINT SIGTERM EXIT; JOBS="$(jobs -p)"; [[ "$JOBS" != "" ]] && kill
 
 # Run `react-scripts` in the GraphiQL directory as well parallel, but pipe the
 # output to `/dev/null`.
-PORT=5001 npm --prefix src/postgraphql/graphiql run start > /dev/null
+PORT=5783 npm --prefix src/postgraphql/graphiql run start > /dev/null
 
 wait

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [ ! -d src/postgraphql/graphiql/node_modules ]; then
+  npm --prefix src/postgraphql/graphiql install
+fi

--- a/src/postgraphql/graphiql/src/components/PostGraphiQL.js
+++ b/src/postgraphql/graphiql/src/components/PostGraphiQL.js
@@ -1,3 +1,4 @@
+// tslint:disable no-console
 import React from 'react'
 import GraphiQL from 'graphiql'
 import { buildClientSchema, introspectionQuery, isType, GraphQLObjectType } from 'graphql'
@@ -56,10 +57,10 @@ class PostGraphiQL extends React.Component {
     const response = await fetch(POSTGRAPHQL_CONFIG.graphqlUrl, {
       method: 'POST',
       headers: Object.assign({
-        'Accept': 'application/json',
+        Accept: 'application/json',
         'Content-Type': 'application/json',
       }, jwtToken ? {
-        'Authorization': `Bearer ${jwtToken}`,
+        Authorization: `Bearer ${jwtToken}`,
       } : {}),
       body: JSON.stringify(graphQLParams),
     })

--- a/src/postgraphql/graphiql/src/index.js
+++ b/src/postgraphql/graphiql/src/index.js
@@ -6,5 +6,5 @@ import PostGraphiQL from './components/PostGraphiQL'
 
 ReactDOM.render(
   <PostGraphiQL/>,
-  document.getElementById('root')
+  document.getElementById('root'),
 )

--- a/src/postgraphql/http/__tests__/setupServerSentEvents-test.js
+++ b/src/postgraphql/http/__tests__/setupServerSentEvents-test.js
@@ -1,7 +1,7 @@
 import setupServerSentEvents from '../setupServerSentEvents'
 
 const http = require('http')
-const EventEmitter = require('events')
+const EventEmitter = require('events') // tslint:disable-line:variable-name
 const request = require('supertest-as-promised')
 
 const _emitter = new EventEmitter()

--- a/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
+++ b/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
@@ -122,7 +122,7 @@ export default function createPostGraphQLHttpRequestHandler (options) {
     // implications though so be careful!)
     //
     // Always enable CORS when developing PostGraphQL because GraphiQL will be
-    // on port 5001.
+    // on port 5783.
     if (options.enableCors || POSTGRAPHQL_ENV === 'development')
       addCORSHeaders(res)
 
@@ -195,7 +195,7 @@ export default function createPostGraphQLHttpRequestHandler (options) {
     if (parseUrl(req).pathname === graphiqlRoute) {
       // If we are developing PostGraphQL, instead just redirect.
       if (POSTGRAPHQL_ENV === 'development') {
-        res.writeHead(302, { 'Location': 'http://localhost:5001' })
+        res.writeHead(302, { 'Location': 'http://localhost:5783' })
         res.end()
         return
       }

--- a/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
+++ b/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
@@ -195,7 +195,7 @@ export default function createPostGraphQLHttpRequestHandler (options) {
     if (parseUrl(req).pathname === graphiqlRoute) {
       // If we are developing PostGraphQL, instead just redirect.
       if (POSTGRAPHQL_ENV === 'development') {
-        res.writeHead(302, { 'Location': 'http://localhost:5783' })
+        res.writeHead(302, { Location: 'http://localhost:5783' })
         res.end()
         return
       }

--- a/src/postgraphql/http/setupServerSentEvents.js
+++ b/src/postgraphql/http/setupServerSentEvents.js
@@ -9,11 +9,11 @@ const setupServerSentEvents = (req, res, options) => {
   res.writeHead(200, {
     'Content-Type': 'text/event-stream',
     'Cache-Control': 'no-cache',
-    'Connection': 'keep-alive'
+    Connection: 'keep-alive',
   })
 
-  const sse = string => {
-    res.write(string)
+  const sse = str => {
+    res.write(str)
     // support running within the compression middleware
     // https://github.com/expressjs/compression#server-sent-events
     if (res.flushHeaders) res.flushHeaders()


### PR DESCRIPTION
Note this merges into the `feat/extend-graphiql-2` branch (not master).

- switches from port 5001 (which conflicted for me so likely will for others) to 5783
- adds a postinstall script to build/dev that detects if the graphiql dependencies have ever been installed and if not installs them (does NOT handle later updates, but it's a good first stab I think)
- fixes a minor issue where the background process killer is too noisy