### PR TITLE
Remove isTypeOf check from collection types

### DIFF
--- a/src/graphql/schema/collection/getCollectionGqlType.ts
+++ b/src/graphql/schema/collection/getCollectionGqlType.ts
@@ -2,7 +2,6 @@ import { GraphQLObjectType, GraphQLFieldConfig, GraphQLNonNull, GraphQLID, Graph
 import { Collection, Condition, ObjectType, Relation, conditionHelpers } from '../../../interface'
 import { memoize2, formatName, buildObject, idSerde } from '../../utils'
 import getNodeInterfaceType from '../node/getNodeInterfaceType'
-import { $$nodeValueCollection } from '../node/createNodeFieldEntry'
 import getGqlType from '../getGqlType'
 import createConnectionGqlField from '../connection/createConnectionGqlField'
 import BuildToken from '../BuildToken'
@@ -36,15 +35,6 @@ function createCollectionGqlType (buildToken: BuildToken, collection: Collection
   return new GraphQLObjectType<ObjectType.Value>({
     name: collectionTypeName,
     description: collection.description,
-
-    // Determines the type of this value. If it came from our `node` field
-    // then that field gave it some extra information about the collection
-    // it came from so we must check that extra information.
-    isTypeOf: value => (
-      value != null && typeof value[$$nodeValueCollection] !== 'undefined'
-        ? value[$$nodeValueCollection] === collection
-        : true
-    ) && type.isTypeOf(value),
 
     // If there is a primary key, this is a node.
     interfaces: primaryKey ? [getNodeInterfaceType(buildToken)] : [],

--- a/src/graphql/schema/node/createNodeFieldEntry.ts
+++ b/src/graphql/schema/node/createNodeFieldEntry.ts
@@ -3,9 +3,8 @@ import { Collection, ObjectType } from '../../../interface'
 import { idSerde, scrib } from '../../utils'
 import BuildToken from '../BuildToken'
 import { $$isQuery } from '../getQueryGqlType'
-import getNodeInterfaceType from './getNodeInterfaceType'
-
-export const $$nodeValueCollection = Symbol('nodeValueCollection')
+import getCollectionGqlType from '../collection/getCollectionGqlType'
+import getNodeInterfaceType, { $$nodeType } from './getNodeInterfaceType'
 
 // TODO: doc
 export default function createNodeFieldEntry (buildToken: BuildToken): [string, GraphQLFieldConfig<mixed, mixed>] {
@@ -56,7 +55,7 @@ export default function createNodeFieldEntry (buildToken: BuildToken): [string, 
       // Add the collection to the value so we can accurately determine the
       // type. This way we will know exactly which collection this is for and
       // can avoid ambiguous `isTypeOf` checks.
-      value[$$nodeValueCollection] = collection
+      value[$$nodeType] = getCollectionGqlType(buildToken, collection)
 
       return value
     },

--- a/src/graphql/schema/node/getNodeInterfaceType.ts
+++ b/src/graphql/schema/node/getNodeInterfaceType.ts
@@ -1,18 +1,20 @@
 import { GraphQLInterfaceType, GraphQLNonNull, GraphQLID } from 'graphql'
 import { memoize1, scrib } from '../../utils'
+import getQueryGqlType, { $$isQuery } from '../getQueryGqlType'
 import BuildToken from '../BuildToken'
 
-// TODO: doc why this is memoized
+export const $$nodeType = Symbol('nodeType')
+
 const getNodeInterfaceType = memoize1(createNodeInterfaceType)
 
 export default getNodeInterfaceType
 
-// TODO: doc
 function createNodeInterfaceType (buildToken: BuildToken): GraphQLInterfaceType<mixed> {
   const { options } = buildToken
   return new GraphQLInterfaceType<mixed>({
     name: 'Node',
     description: `An object with a globally unique ${scrib.type(GraphQLID)}.`,
+    resolveType: (value: {}) => value === $$isQuery ? getQueryGqlType(buildToken) : value[$$nodeType],
     fields: {
       [options.nodeIdFieldName]: {
         description: 'A globally unique identifier. Can be used in various places throughout the system to identify this single value.',


### PR DESCRIPTION
A small refactor that removes the main reason we need an `isTypeOf` function in collection types. This gives us a super small performance win, but also makes it easier to implement computed column performance wins and selective column selections.