### PR TITLE
Add Optional Param for JWT Audience + Auth0 roles Support

### DIFF
--- a/docs/library.md
+++ b/docs/library.md
@@ -50,6 +50,7 @@ Arguments include:
   - `graphiqlRoute`: The endpoint the GraphiQL query interface will listen on (**NOTE:** GraphiQL will not be enabled unless the `graphiql` option is set to `true`). Defaults to `/graphiql`.
   - `pgDefaultRole`: The default Postgres role to use. If no role was provided in a provided JWT token, this role will be used.
   - `jwtSecret`: The secret for your JSON web tokens. This will be used to verify tokens in the `Authorization` header, and signing JWT tokens you return in procedures.
+  - `jwtAudience`: The audience for your JSON web tokens. If not specified, it will default to `postgraphql`.
   - `jwtPgTypeIdentifier`: The Postgres type identifier for the compound type which will be signed as a JWT token if ever found as the return type of a procedure. Can be of the form: `my_schema.my_type`. You may use quotes as needed: `"my-special-schema".my_type`.
   - `watchPg`: When true, PostGraphQL will watch your database schemas and re-create the GraphQL API whenever your schema changes, notifying you as it does. This feature requires an event trigger to be added to the database by a superuser. When enabled PostGraphQL will try to add this trigger, if you did not connect as a superuser you will get a warning and the trigger won’t be added.
   - `disableQueryLog`: Turns off GraphQL query logging. By default PostGraphQL will log every GraphQL query it processes along with some other information. Set this to `true` to disable that feature.

--- a/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
+++ b/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
@@ -284,6 +284,7 @@ export default function createPostGraphQLHttpRequestHandler (options) {
       await pgClient.query('begin')
       pgRole = await setupRequestPgClientTransaction(req, pgClient, {
         jwtSecret: options.jwtSecret,
+        jwtAudience: options.jwtAudience,
         pgDefaultRole: options.pgDefaultRole,
       })
 

--- a/src/postgraphql/http/setupRequestPgClientTransaction.js
+++ b/src/postgraphql/http/setupRequestPgClientTransaction.js
@@ -33,28 +33,28 @@ export default async function setupRequestPgClientTransaction (request, pgClient
   // If we were provided a JWT token, let us try to verify it. If verification
   // fails we want to throw an error.
   if (jwtToken) {
-      // Try to run `jwt.verify`. If it fails, capture the error and re-throw it
-      // as a 403 error because the token is not trustworthy.
-      try {
-          // Check optional JWT audience. if none provided, default to postgraphql.
-          if (jwtAudience == undefined)
-              jwtAudience = "postgraphql";
+    // Try to run `jwt.verify`. If it fails, capture the error and re-throw it
+    // as a 403 error because the token is not trustworthy.
+    try {
+      // Check optional JWT audience. if none provided, default to postgraphql.
+      if (jwtAudience == undefined)
+        jwtAudience = "postgraphql";
           
-          jwtClaims = jwt.verify(jwtToken, jwtSecret, { audience: jwtAudience });
+      jwtClaims = jwt.verify(jwtToken, jwtSecret, { audience: jwtAudience });
           
-          // If there is a `role` property in the claims, use that instead of our
-          // default role. If no `role` property is found, check if there is a `roles`
-          // array. If so, use the first role inside of that array. The `roles`
-          // bring support for JWTs produced by Auth0.
-          if (jwtClaims.role != null)
-              role = jwtClaims.role;
-          else if (jwtClaims.roles[0] != null)
-              role = jwtClaims.roles[0];
-      }
-      catch (error) {
-          error.statusCode = 403;
-          throw error;
-      }
+      // If there is a `role` property in the claims, use that instead of our
+      // default role. If no `role` property is found, check if there is a `roles`
+      // array. If so, use the first role inside of that array. The `roles`
+      // bring support for JWTs produced by Auth0.
+      if (jwtClaims.role != null)
+        role = jwtClaims.role;
+      else if (jwtClaims.roles[0] != null)
+        role = jwtClaims.roles[0];
+    }
+    catch (error) {
+      error.statusCode = 403;
+      throw error;
+    }
   }
 
   // Instantiate a map of local settings. This map will be transformed into a

--- a/src/postgraphql/http/setupRequestPgClientTransaction.js
+++ b/src/postgraphql/http/setupRequestPgClientTransaction.js
@@ -37,11 +37,11 @@ export default async function setupRequestPgClientTransaction (request, pgClient
     // as a 403 error because the token is not trustworthy.
     try {
       // Check optional JWT audience. if none provided, default to postgraphql.
-      if (jwtAudience == undefined)
-        jwtAudience = "postgraphql"
-          
+      if (jwtAudience === undefined)
+        jwtAudience = 'postgraphql'
+
       jwtClaims = jwt.verify(jwtToken, jwtSecret, { audience: jwtAudience })
-          
+
       // If there is a `role` property in the claims, use that instead of our
       // default role. If no `role` property is found, check if there is a `roles`
       // array. If so, use the first role inside of that array. The `roles`

--- a/src/postgraphql/http/setupRequestPgClientTransaction.js
+++ b/src/postgraphql/http/setupRequestPgClientTransaction.js
@@ -38,22 +38,22 @@ export default async function setupRequestPgClientTransaction (request, pgClient
     try {
       // Check optional JWT audience. if none provided, default to postgraphql.
       if (jwtAudience == undefined)
-        jwtAudience = "postgraphql";
+        jwtAudience = "postgraphql"
           
-      jwtClaims = jwt.verify(jwtToken, jwtSecret, { audience: jwtAudience });
+      jwtClaims = jwt.verify(jwtToken, jwtSecret, { audience: jwtAudience })
           
       // If there is a `role` property in the claims, use that instead of our
       // default role. If no `role` property is found, check if there is a `roles`
       // array. If so, use the first role inside of that array. The `roles`
       // bring support for JWTs produced by Auth0.
       if (jwtClaims.role != null)
-        role = jwtClaims.role;
+        role = jwtClaims.role
       else if (jwtClaims.roles[0] != null)
-        role = jwtClaims.roles[0];
+        role = jwtClaims.roles[0]
     }
     catch (error) {
-      error.statusCode = 403;
-      throw error;
+      error.statusCode = 403
+      throw error
     }
   }
 

--- a/src/postgraphql/http/setupRequestPgClientTransaction.js
+++ b/src/postgraphql/http/setupRequestPgClientTransaction.js
@@ -17,7 +17,7 @@ const jwt = require('jsonwebtoken')
 // client. If this happens it’s a huge security vulnerability. Never using the
 // keyword `return` in this function is a good first step. You can still throw
 // errors, however, as this will stop the request execution.
-export default async function setupRequestPgClientTransaction (request, pgClient, { jwtSecret, pgDefaultRole } = {}) {
+export default async function setupRequestPgClientTransaction (request, pgClient, { jwtSecret, jwtAudience, pgDefaultRole } = {}) {
   // Get the JWT token string from our request.
   const jwtToken = getJWTToken(request)
 
@@ -33,20 +33,28 @@ export default async function setupRequestPgClientTransaction (request, pgClient
   // If we were provided a JWT token, let us try to verify it. If verification
   // fails we want to throw an error.
   if (jwtToken) {
-    // Try to run `jwt.verify`. If it fails, capture the error and re-throw it
-    // as a 403 error because the token is not trustworthy.
-    try {
-      jwtClaims = jwt.verify(jwtToken, jwtSecret, { audience: 'postgraphql' })
-
-      // If there is a `role` property in the claims, use that instead of our
-      // default role.
-      if (jwtClaims.role != null)
-        role = jwtClaims.role
-    }
-    catch (error) {
-      error.statusCode = 403
-      throw error
-    }
+      // Try to run `jwt.verify`. If it fails, capture the error and re-throw it
+      // as a 403 error because the token is not trustworthy.
+      try {
+          // Check optional JWT audience. if none provided, default to postgraphql.
+          if (jwtAudience == undefined)
+              jwtAudience = "postgraphql";
+          
+          jwtClaims = jwt.verify(jwtToken, jwtSecret, { audience: jwtAudience });
+          
+          // If there is a `role` property in the claims, use that instead of our
+          // default role. If no `role` property is found, check if there is a `roles`
+          // array. If so, use the first role inside of that array. The `roles`
+          // bring support for JWTs produced by Auth0.
+          if (jwtClaims.role != null)
+              role = jwtClaims.role;
+          else if (jwtClaims.roles[0] != null)
+              role = jwtClaims.roles[0];
+      }
+      catch (error) {
+          error.statusCode = 403;
+          throw error;
+      }
   }
 
   // Instantiate a map of local settings. This map will be transformed into a


### PR DESCRIPTION
### Custom JWT Audience
Currently, Postgraphql requires that any JWT have an audience of `postgraphql`. With this PR, the JS API now allows for a custom audience to be set. If none is provided, it will default to `postgraphql`.

### Auth0 roles Support
Currently, Auth0 has custom rules to add properties to your JWT. The default implementation of the `role` rule, adds an array of `roles`. With this PR, Postgraphql will check for a `role` property, but if a `roles` array exists, it will override and choose the first role in the array.

Example JWT from Auth0 with default implemenation of the `roles` array.
```json
{
   ...
  "roles": [
    "user_role"
  ],
  "clientID": "exampleClientID",
  "created_at": "2016-12-27T17:50:30.013Z",
  "iss": "exampleISS",
  "sub": "exampleSUB",
  "aud": "exampleAUD",
  "exp": 1483016195,
  "iat": 1482980195
}
```

A discussion of this can be found in the following issue: #292 