### PR TITLE
target es5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 
 node_js:
   - "6"
+  - "4"
 
 addons:
   postgresql: "9.4"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "supertest-as-promised": "^4.0.2",
     "ts-node": "^1.7.0",
     "tslint": "^4.2.0",
-    "typescript": "^2.0.10"
+    "typescript": "^2.2.0-dev.20170107"
   },
   "jest": {
     "transform": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "allowJs": true,
     "rootDir": "src",
     "outDir": "build",
-    "target": "es6",
+    "target": "es5",
     "module": "commonjs",
     "moduleResolution": "node",
     "inlineSourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "strictNullChecks": true,
     "noFallthroughCasesInSwitch": true,
     "noUnusedParameters": true,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "lib": ["es2015"]
   },
   "exclude": [
     "index.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "allowJs": true,
     "rootDir": "src",
     "outDir": "build",
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "moduleResolution": "node",
     "inlineSourceMap": true,


### PR DESCRIPTION
targets es5 instead of es6 for AWS Lambda support

fixes https://github.com/calebmer/postgraphql/issues/301