### PR TITLE
fix(postgraphql): try getting error code from error.statusCode before falling back to 500

### DIFF
--- a/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
+++ b/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
@@ -308,7 +308,7 @@ export default function createPostGraphQLHttpRequestHandler (options) {
     }
     catch (error) {
       // Set our status code and send the client our results!
-      if (res.statusCode === 200) res.statusCode = error.status || 500
+      if (res.statusCode === 200) res.statusCode = error.status || error.statusCode || 500
       result = { errors: [error] }
 
       // If the status code is 500, let’s log our error.


### PR DESCRIPTION
The HTTP error handler was looking in `error.status` for the status code to return to the client, but some error codes were being set in `error.statusCode`.

Fixes half the error reported in #287 where the JWT error throws a 500 rather than a 403.