### PR TITLE
fix(postgres): prevent processing same constraint twice

### DIFF
--- a/src/postgres/introspection/PgCatalog.ts
+++ b/src/postgres/introspection/PgCatalog.ts
@@ -20,7 +20,7 @@ class PgCatalog {
   private _procedures: Set<PgCatalogProcedure> = new Set()
 
   constructor (objects: Array<PgCatalogObject>) {
-    const foundConstraints:Set<String> = new Set()
+    const foundConstraints: Set<String> = new Set()
     // Build an in-memory index of all our objects for ease of use:
     for (const object of objects) {
       switch (object.kind) {
@@ -37,13 +37,13 @@ class PgCatalog {
           this._types.set(object.id, object)
           break
         case 'constraint':
-          var constraint: PgCatalogForeignKeyConstraint = object as PgCatalogForeignKeyConstraint
-          var constraintKey = JSON.stringify({
+          const constraint: PgCatalogForeignKeyConstraint = object as PgCatalogForeignKeyConstraint
+          const constraintKey = JSON.stringify({
             type: constraint.type,
             classId: constraint.classId,
             foreignClassId: constraint.foreignClassId,
             keyAttributeNums: constraint.keyAttributeNums,
-            foreignKeyAttributeNums: constraint.foreignKeyAttributeNums
+            foreignKeyAttributeNums: constraint.foreignKeyAttributeNums,
           })
           if (!foundConstraints.has(constraintKey)) {
             foundConstraints.add(constraintKey)

--- a/src/postgres/introspection/PgCatalog.ts
+++ b/src/postgres/introspection/PgCatalog.ts
@@ -4,6 +4,7 @@ import PgCatalogClass from './object/PgCatalogClass'
 import PgCatalogAttribute from './object/PgCatalogAttribute'
 import PgCatalogType from './object/PgCatalogType'
 import PgCatalogConstraint from './object/PgCatalogConstraint'
+import { PgCatalogForeignKeyConstraint } from './object/PgCatalogConstraint'
 import PgCatalogProcedure from './object/PgCatalogProcedure'
 
 /**
@@ -19,6 +20,7 @@ class PgCatalog {
   private _procedures: Set<PgCatalogProcedure> = new Set()
 
   constructor (objects: Array<PgCatalogObject>) {
+    const foundConstraints:Set<String> = new Set()
     // Build an in-memory index of all our objects for ease of use:
     for (const object of objects) {
       switch (object.kind) {
@@ -35,7 +37,18 @@ class PgCatalog {
           this._types.set(object.id, object)
           break
         case 'constraint':
-          this._constraints.add(object)
+          var constraint: PgCatalogForeignKeyConstraint = object as PgCatalogForeignKeyConstraint
+          var constraintKey = JSON.stringify({
+            type: constraint.type,
+            classId: constraint.classId,
+            foreignClassId: constraint.foreignClassId,
+            keyAttributeNums: constraint.keyAttributeNums,
+            foreignKeyAttributeNums: constraint.foreignKeyAttributeNums
+          })
+          if (!foundConstraints.has(constraintKey)) {
+            foundConstraints.add(constraintKey)
+            this._constraints.add(object)
+          }
           break
         case 'procedure':
           this._procedures.add(object)

--- a/src/postgres/introspection/__tests__/PgCatalog-test.js
+++ b/src/postgres/introspection/__tests__/PgCatalog-test.js
@@ -29,9 +29,13 @@ const mockTypes = [
 ]
 
 const mockConstraints = [
-  { kind: 'constraint' },
-  { kind: 'constraint' },
-  { kind: 'constraint' },
+  { kind: 'constraint', type: 'f', classId: '1', foreignClassId: '2', keyAttributeNums: [3], foreignKeyAttributeNums: [4] },
+  { kind: 'constraint', type: 'f', classId: '1', foreignClassId: '2', keyAttributeNums: [3], foreignKeyAttributeNums: [4] },
+  { kind: 'constraint', type: 'f', classId: '1', foreignClassId: '2', keyAttributeNums: [3], foreignKeyAttributeNums: [5] },
+  { kind: 'constraint', type: 'f', classId: '1', foreignClassId: '2', keyAttributeNums: [4], foreignKeyAttributeNums: [4] },
+  { kind: 'constraint', type: 'f', classId: '1', foreignClassId: '3', keyAttributeNums: [3], foreignKeyAttributeNums: [4] },
+  { kind: 'constraint', type: 'f', classId: '2', foreignClassId: '2', keyAttributeNums: [3], foreignKeyAttributeNums: [4] },
+  { kind: 'constraint', type: 'a', classId: '1', foreignClassId: '2', keyAttributeNums: [3], foreignKeyAttributeNums: [4] }
 ]
 
 const mockObjects = [
@@ -178,6 +182,8 @@ test('getTypeByName will get a type by its name', () => {
   expect(catalog.getTypeByName('c', 'a')).toBe(undefined)
 })
 
-test('getConstraints will get all constraints', () => {
-  expect(catalog.getConstraints()).toEqual(mockConstraints)
+test('getConstraints will get all unique constraints', () => {
+  var testConstraints = mockConstraints.concat()
+  testConstraints.splice(1, 1)
+  expect(catalog.getConstraints()).toEqual(testConstraints)
 })

--- a/src/postgres/introspection/__tests__/PgCatalog-test.js
+++ b/src/postgres/introspection/__tests__/PgCatalog-test.js
@@ -35,7 +35,7 @@ const mockConstraints = [
   { kind: 'constraint', type: 'f', classId: '1', foreignClassId: '2', keyAttributeNums: [4], foreignKeyAttributeNums: [4] },
   { kind: 'constraint', type: 'f', classId: '1', foreignClassId: '3', keyAttributeNums: [3], foreignKeyAttributeNums: [4] },
   { kind: 'constraint', type: 'f', classId: '2', foreignClassId: '2', keyAttributeNums: [3], foreignKeyAttributeNums: [4] },
-  { kind: 'constraint', type: 'a', classId: '1', foreignClassId: '2', keyAttributeNums: [3], foreignKeyAttributeNums: [4] }
+  { kind: 'constraint', type: 'a', classId: '1', foreignClassId: '2', keyAttributeNums: [3], foreignKeyAttributeNums: [4] },
 ]
 
 const mockObjects = [
@@ -183,7 +183,7 @@ test('getTypeByName will get a type by its name', () => {
 })
 
 test('getConstraints will get all unique constraints', () => {
-  var testConstraints = mockConstraints.concat()
+  const testConstraints = mockConstraints.concat()
   testConstraints.splice(1, 1)
   expect(catalog.getConstraints()).toEqual(testConstraints)
 })


### PR DESCRIPTION
Right now it is possible that the introspection sql script (and by extension postgres) returns the same constraint (with different names) twice. In this case you will get the error of #316. This PR closes #316 by storing a key/hash for a constraint and checking for its existence before adding it to the constraint set _(making it a true constraint set and not a constraint list)_.