### PR TITLE
fix(deps): restrict graphql version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dataloader": "^1.2.0",
     "debug": "^2.3.3",
     "finalhandler": "^0.5.1",
-    "graphql": ">=0.6.0 <1.0.0",
+    "graphql": ">=0.6.0 <0.9.0",
     "http-errors": "^1.5.1",
     "jsonwebtoken": "^7.1.9",
     "parseurl": "^1.3.1",


### PR DESCRIPTION
See https://github.com/calebmer/postgraphql/pull/319 and #321; this is clearly breaking things for people who want to get started with postgraphql, so we should get a simple fix out ASAP before fixing it more permanently by renaming `__id` later. 

@calebmer can you release this one commit as a bugfix release?