### PR TITLE
Allowing graphiql to work both during development and when published

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -17,4 +17,4 @@ echo "Building GraphiQL"
 
 echo "Moving GraphiQL build output"
 mkdir -p build/postgraphql/graphiql/public
-mv src/postgraphql/graphiql/build/* build/postgraphql/graphiql/public
+cp -Rv src/postgraphql/graphiql/build/* build/postgraphql/graphiql/public

--- a/scripts/lint
+++ b/scripts/lint
@@ -4,4 +4,4 @@ npm_bin=$(npm bin)
 
 set -e
 
-$npm_bin/tslint $(find src -name "*.[tj]s" -a \! -wholename '*/node_modules/*') $@
+$npm_bin/tslint **/*.ts **/*.js $@

--- a/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
+++ b/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
@@ -30,7 +30,7 @@ const { POSTGRAPHQL_ENV } = process.env
 const debugGraphql = new Debugger('postgraphql:graphql')
 const debugRequest = new Debugger('postgraphql:request')
 
-export const graphiqlDirectory = resolvePath(__dirname, '../graphiql/public')
+export const graphiqlDirectory = resolvePath(__dirname, '../graphiql/build')
 
 /**
  * The favicon file in `Buffer` format. We can send a `Buffer` directly to the
@@ -52,7 +52,7 @@ const favicon = new Promise((resolve, reject) => {
  * @type {Promise<string>}
  */
 const origGraphiqlHtml = new Promise((resolve, reject) => {
-  readFile(resolvePath(__dirname, '../graphiql/public/index.html'), 'utf8', (error, data) => {
+  readFile(resolvePath(graphiqlDirectory, 'index.html'), 'utf8', (error, data) => {
     if (error) reject(error)
     else resolve(data)
   })


### PR DESCRIPTION
It seems like the recent graphiql improvements don't work well when used in development mode since [the build script moves the build folder](https://github.com/calebmer/postgraphql/blob/939a91ed20fc183bcd0fc8367a7b6af891e6a2de/scripts/build#L20) out of the range of [`createPostGraphQLHttpRequestHandler`](https://github.com/calebmer/postgraphql/blob/939a91ed20fc183bcd0fc8367a7b6af891e6a2de/src/postgraphql/http/createPostGraphQLHttpRequestHandler.d.ts) which is no problem when the TypeScript code is built but when [running with scripts/dev](https://github.com/calebmer/postgraphql/blob/939a91ed20fc183bcd0fc8367a7b6af891e6a2de/scripts/dev#L18) it will render [`src/postgraphql/graphiql/public/index.html`](https://github.com/calebmer/postgraphql/blob/939a91ed20fc183bcd0fc8367a7b6af891e6a2de/src/postgraphql/graphiql/public/index.html) which is rather empty. This PR changes the `mv` to a `cp` and changes the reference of the root folder to work in development mode as well.
(Closes #330)