### PR TITLE
fix(postgres): fix processing money type

### DIFF
--- a/src/postgres/inventory/type/scalar/pgFloatType.ts
+++ b/src/postgres/inventory/type/scalar/pgFloatType.ts
@@ -2,6 +2,11 @@ import { AdapterType, floatType } from '../../../../interface'
 import { sql } from '../../../utils'
 import PgType from '../PgType'
 
+// In the absence of /\p{Sc}/ to match all currency symbols, we get the
+// following regexp from http://stackoverflow.com/a/27175364/141284
+const CURRENY_SYMBOL_REGEXP =
+  /^[\$\xA2-\xA5\u058F\u060B\u09F2\u09F3\u09FB\u0AF1\u0BF9\u0E3F\u17DB\u20A0-\u20BD\uA838\uFDFC\uFE69\uFF04\uFFE0\uFFE1\uFFE5\uFFE6]/
+
 const pgFloatType: PgType<number> & AdapterType<number> = {
   kind: 'ADAPTER',
   baseType: floatType,
@@ -11,7 +16,7 @@ const pgFloatType: PgType<number> & AdapterType<number> = {
     if (typeof value === 'string') {
       // If this number represents money, it has some extra trimmings that
       // need to be fixed.
-      if (value.startsWith('$'))
+      if (CURRENY_SYMBOL_REGEXP.test(value))
         return parseFloat(value.slice(1).replace(',', ''))
 
       return parseFloat(value)


### PR DESCRIPTION
Finally got around to figuring out what was wrong with the tests for me...

I'm concerned that the removal of commas might be localization dependent too, for example in continental Europe they tend to place commas where we place dots and vice versa; e.g. €1.234,56 - if this is the case for the money type then things are going to go wrong... 😜 