### PR TITLE
let PG* environment variables setup test connection

### DIFF
--- a/src/postgres/__tests__/fixtures/pgPool.ts
+++ b/src/postgres/__tests__/fixtures/pgPool.ts
@@ -1,9 +1,16 @@
 import { Pool } from 'pg'
 import { parse as parsePgConnectionString } from 'pg-connection-string'
 
-const pgUrl = process.env.TEST_PG_URL || 'postgres://localhost:5432/postgraphql_test'
+const pgCfg = process.env.TEST_PG_URL || null
 
-const pgPool = new Pool(Object.assign({}, parsePgConnectionString(pgUrl), {
+if (pgCfg) {
+  pgCfg = parsePgConnectionString(pgCfg)
+} else {
+  // be careful to not stomp on PG* environment variables
+  pgCfg = {database: process.env.PGDATABASE || 'postgraphql_test'}
+}
+
+const pgPool = new Pool(Object.assign({}, pgCfg, {
   max: 15,
   idleTimeoutMillis: 500,
 }))


### PR DESCRIPTION
A simple change to not break expectations. I was surprised PGHOST did not work.