### PR TITLE
feat(postgraphql): inject custom settings into the database

### DIFF
--- a/src/postgraphql/http/__tests__/createPostGraphQLHttpRequestHandler-test.js
+++ b/src/postgraphql/http/__tests__/createPostGraphQLHttpRequestHandler-test.js
@@ -569,7 +569,7 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
             values: [
               'foo.string', 'test1',
               'foo.number', '42',
-              'foo.boolean', 'true'
+              'foo.boolean', 'true',
             ],
           },
         ],

--- a/src/postgraphql/http/__tests__/createPostGraphQLHttpRequestHandler-test.js
+++ b/src/postgraphql/http/__tests__/createPostGraphQLHttpRequestHandler-test.js
@@ -547,7 +547,9 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
       pgClient.release.mockClear()
       const server = createServer({
         pgSettings: {
-          'foo.bar': 'test1',
+          'foo.string': 'test1',
+          'foo.number': 42,
+          'foo.boolean': true,
         },
       })
       await (
@@ -563,8 +565,12 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
         ['begin'],
         [
           {
-            text: 'select set_config($1, $2, true)',
-            values: ['foo.bar', 'test1'],
+            text: 'select set_config($1, $2, true), set_config($3, $4, true), set_config($5, $6, true)',
+            values: [
+              'foo.string', 'test1',
+              'foo.number', '42',
+              'foo.boolean', 'true'
+            ],
           },
         ],
         ['commit'],

--- a/src/postgraphql/http/createPostGraphQLHttpRequestHandler.d.ts
+++ b/src/postgraphql/http/createPostGraphQLHttpRequestHandler.d.ts
@@ -73,4 +73,9 @@ export default function createPostGraphQLHttpRequestHandler (config: {
   // The size can be given as a human-readable string, such as '200kB' or '5MB'
   // (case insensitive).
   bodySizeLimit?: string,
+
+  // Allows the definition of custom postgres settings which get injected in
+  // each transaction via set_config. They can then be used via current_setting
+  // in postgres functions.
+  pgSettings?: { [key: string]: mixed },
 }): HttpRequestHandler

--- a/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
+++ b/src/postgraphql/http/createPostGraphQLHttpRequestHandler.js
@@ -65,7 +65,7 @@ const origGraphiqlHtml = new Promise((resolve, reject) => {
  * @param {GraphQLSchema} graphqlSchema
  */
 export default function createPostGraphQLHttpRequestHandler (options) {
-  const { getGqlSchema, pgPool } = options
+  const { getGqlSchema, pgPool, pgSettings } = options
 
   // Gets the route names for our GraphQL endpoint, and our GraphiQL endpoint.
   const graphqlRoute = options.graphqlRoute || '/graphql'
@@ -395,6 +395,7 @@ export default function createPostGraphQLHttpRequestHandler (options) {
         jwtToken,
         jwtSecret: options.jwtSecret,
         pgDefaultRole: options.pgDefaultRole,
+        pgSettings,
       }, context => {
         pgRole = context.pgRole
         return executeGraphql(

--- a/src/postgraphql/postgraphql.ts
+++ b/src/postgraphql/postgraphql.ts
@@ -25,6 +25,7 @@ type PostGraphQLOptions = {
   exportJsonSchemaPath?: string,
   exportGqlSchemaPath?: string,
   bodySizeLimit?: string,
+  pgSettings?: { [key: string]: mixed },
 }
 
 /**

--- a/src/postgraphql/withPostGraphQLContext.ts
+++ b/src/postgraphql/withPostGraphQLContext.ts
@@ -144,7 +144,7 @@ async function setupPgClientTransaction ({
   // this prevents an accidentional overwriting
   if (typeof pgSettings === 'object') {
     for (const key of Object.keys(pgSettings)) {
-      localSettings.set(key, pgSettings[key])
+      localSettings.set(key, String(pgSettings[key]))
     }
   }
 

--- a/src/postgraphql/withPostGraphQLContext.ts
+++ b/src/postgraphql/withPostGraphQLContext.ts
@@ -36,11 +36,13 @@ export default async function withPostGraphQLContext(
     jwtToken,
     jwtSecret,
     pgDefaultRole,
+    pgSettings,
   }: {
     pgPool: Pool,
     jwtToken?: string,
     jwtSecret?: string,
     pgDefaultRole?: string,
+    pgSettings?: { [key: string]: mixed },
   },
   callback: (context: mixed) => Promise<ExecutionResult>,
 ): Promise<ExecutionResult> {
@@ -60,6 +62,7 @@ export default async function withPostGraphQLContext(
       jwtToken,
       jwtSecret,
       pgDefaultRole,
+      pgSettings,
     })
 
     return await callback({
@@ -89,11 +92,13 @@ async function setupPgClientTransaction ({
   jwtToken,
   jwtSecret,
   pgDefaultRole,
+  pgSettings,
 }: {
   pgClient: Client,
   jwtToken?: string,
   jwtSecret?: string,
   pgDefaultRole?: string,
+  pgSettings?: { [key: string]: mixed },
 }): Promise<string | undefined> {
   // Setup our default role. Once we decode our token, the role may change.
   let role = pgDefaultRole
@@ -134,6 +139,14 @@ async function setupPgClientTransaction ({
   // Instantiate a map of local settings. This map will be transformed into a
   // Sql query.
   const localSettings = new Map<string, mixed>()
+
+  // Set the custom provided settings before jwt claims and role are set
+  // this prevents an accidentional overwriting
+  if (typeof pgSettings === 'object') {
+    for (const key of Object.keys(pgSettings)) {
+      localSettings.set(key, pgSettings[key])
+    }
+  }
 
   // If there is a rule, we want to set the root `role` setting locally
   // to be our role. The role may only be null if we have no default role.


### PR DESCRIPTION
This pull request adds the `pgSettings` configuration parameter to `postgraphql` middleware function. With this parameter it is possible to set custom config values to the postgres connection. These settings can then be accessed via `current_setting('my.custom.setting')` in all stored procedures. This is analog to the usage of the `jwt.claims` settings but can be defined at middleware initialisation time.

I hope you like it.